### PR TITLE
Fix: github action running twice for a PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - '**'
-
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
### Issue
Link to the ticket: [Github action should run once (currently running twice) on a PR - Issue#202](https://github.com/Real-Dev-Squad/website-dashboard/issues/202)

### Solution Implemented
- Removed the push condition from `.github/workflows/test.yml` file.
- It now runs the GitHub action only once instead of running it twice on a PR.

### Screenshot of the problem
![Screenshot from 2022-09-11 17-23-50](https://user-images.githubusercontent.com/31928236/189526136-1d481ea3-c675-4863-8563-d09954705f90.png)

### Screenshot after fixing the problem
![Screenshot from 2022-09-11 17-25-12](https://user-images.githubusercontent.com/31928236/189526189-cbceade7-5627-4e70-aaa5-01d859a10605.png)
