### PR TITLE
Changed joined_discord to discordJoinedAt in the UserDetailsSection

### DIFF
--- a/users/discord/components/UserDetailsSection.js
+++ b/users/discord/components/UserDetailsSection.js
@@ -2,7 +2,7 @@
 const { createElement } = react;
 
 export const UserDetailsSection = ({
-  user: { first_name, username, discordId, joined_discord },
+  user: { first_name, username, discordId, discordJoinedAt },
 }) => {
   return createElement('section', { class: 'user_details_section' }, [
     createElement('div', { class: 'user_details_field' }, [
@@ -19,7 +19,7 @@ export const UserDetailsSection = ({
     ]),
     createElement('div', { class: 'user_details_field' }, [
       createElement('span', {}, ['Joined RDS server on: ']),
-      createElement('span', {}, [new Date(joined_discord).toUTCString()]),
+      createElement('span', {}, [new Date(discordJoinedAt).toUTCString()]),
     ]),
     createElement('div', { class: 'user_details_field' }, [
       createElement('span', {}, ['User Management: ']),


### PR DESCRIPTION
## Description
This PR fixes the issue where the UI shows an "Invalid date" due to an incorrect attribute name. The attribute should be `discordJoinedAt` instead of `joined_discord`. The necessary changes have been made in the `UserDetailsSection` file to address this issue.

## Changes Made
- Renamed `joined_discord` attribute to `discordJoinedAt` in the `UserDetailsSection` file.

## Related Issue
Please refer to the related issue for more context: #385 

## Checklist
- [x] I have tested the changes locally and verified that the issue is resolved.

## Screenshots
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/111289485/3fb2ba2c-ca85-4c82-a2af-e05092b8f354)
