### PR TITLE
Feat/group selection UI tweaks

### DIFF
--- a/groups/style.css
+++ b/groups/style.css
@@ -68,6 +68,7 @@
   justify-content: center;
   flex-direction: column;
   gap: 10px;
+  position: relative;
 }
 
 .groups {
@@ -162,6 +163,12 @@
   border: none;
 }
 
+.btn-add-role {
+  position: absolute;
+  top: 3%;
+  left: 5%;
+}
+
 /*
 *
     LOADER CLASSES
@@ -202,6 +209,9 @@ NOT VERIFIED TEXT ABOVE
 }
 
 @media (max-width: 650px) {
+  .btn-add-role {
+    position: static;
+  }
   .manage-groups {
     flex-direction: column-reverse;
     padding: 1.2rem;

--- a/groups/style.css
+++ b/groups/style.css
@@ -111,6 +111,10 @@
   margin-bottom: 0.6rem;
   border-radius: 0.6rem;
 }
+.groups-list li:hover {
+  cursor: pointer;
+  background-color: var(--color-active-groups-background);
+}
 .group-name {
   font-size: larger;
 }


### PR DESCRIPTION
This PR has Discord groups selection UI tweaks #411 

Added:
- Repositioned the add role button towards top-left
- Hover effect while hovering over the group list item and mouse pointer


Before:
<img width="1512" alt="Screenshot 2023-07-21 at 7 07 51 PM" src="https://github.com/Real-Dev-Squad/website-dashboard/assets/66241121/d5794cfe-85ef-4e90-9b29-ea88ed5843ab">



After:
<img width="1512" alt="Screenshot 2023-07-21 at 7 07 56 PM" src="https://github.com/Real-Dev-Squad/website-dashboard/assets/66241121/37cb081e-4564-48e7-8afe-41912b4ecb7d">

