### PR TITLE
fix: add option to sync Idle and Active Users on syncUsersStatus button

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,13 @@
     </nav>
 
     <section id="sync-buttons" class="element-display-remove">
+
       <div class="button-container">
-        <button class="action-button" id="sync-users-status">
+        <button class="action-button" id="sync-unverified-users">
           <span class="spinner"></span>
-          Sync Users Status
+          Sync Unverified Users
         </button>
-        <div class="status" id="sync-users-status-update"></div>
+        <div class="status" id="sync-unverified-users-update"></div>
       </div>
 
       <div class="button-container">
@@ -36,12 +37,13 @@
       </div>
 
       <div class="button-container">
-        <button class="action-button" id="sync-unverified-users">
+        <button class="action-button" id="sync-users-status">
           <span class="spinner"></span>
-          Sync Unverified Users
+          Sync Users Status
         </button>
-        <div class="status" id="sync-unverified-users-update"></div>
+        <div class="status" id="sync-users-status-update"></div>
       </div>
+
     </section>
 
     <section class="buttonSection">

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
     </nav>
 
     <section id="sync-buttons" class="element-display-remove">
-
       <div class="button-container">
         <button class="action-button" id="sync-unverified-users">
           <span class="spinner"></span>
@@ -43,7 +42,6 @@
         </button>
         <div class="status" id="sync-users-status-update"></div>
       </div>
-
     </section>
 
     <section class="buttonSection">

--- a/script.js
+++ b/script.js
@@ -23,7 +23,7 @@ function getCurrentTimestamp() {
 export async function showSuperUserOptions(...privateBtns) {
   try {
     const isSuperUser = await checkUserIsSuperUser();
-    if (true) {
+    if (isSuperUser) {
       privateBtns.forEach((btn) =>
         btn.classList.remove('element-display-remove'),
       );

--- a/script.js
+++ b/script.js
@@ -83,38 +83,38 @@ async function handleSync(
   const wrapper = button.parentElement;
   const spinner = wrapper.querySelector('.spinner');
   const status = wrapper.querySelector('.status');
-  //console.log('button', button.id);
+  
   button.disabled = true;
   button.classList.add(DISABLED);
   spinner.style.display = 'inline-block';
   status.textContent = SYNC_IN_PROGRESS;
 
-
   if(button.id === "sync-users-status") {
     try {
-      const response = await fetch(`${API_BASE_URL}${endpoint.userStatusUpdate}`, {
+      const userStatus = fetch(`${API_BASE_URL}${endpoint.userStatusUpdate}`, {
         method: method.userStatusMethod,
         credentials: 'include',
       });
       
-      const idleData = await fetch(`${API_BASE_URL}${endpoint.idle}`, {
+      const idleUsers = fetch(`${API_BASE_URL}${endpoint.idle}`, {
         method: method.idleMethod,
         credentials: 'include',
       })
       .then((res) => res.json())
       .then((data) => data.data.users)
-      console.log('idleData', idleData);
+
+      const [ userStatusResponse, idleUsersData ] = await Promise.all([ userStatus, idleUsers ]);
 
       const batchResponse = await fetch(`${API_BASE_URL}${endpoint.batchIdle}`, {
         headers: {
           'Content-Type': 'application/json'
         },
         method: method.batchIdleMethod,
-        body: JSON.stringify({ users: idleData }),
+        body: JSON.stringify({ users: idleUsersData }),
         credentials: 'include'
       })
 
-      if (response.ok && batchResponse.ok) {
+      if (userStatusResponse.ok && batchResponse.ok) {
         status.textContent = SYNC_SUCCESSFUL;
         const lastSyncTimestamp = getCurrentTimestamp();
   

--- a/script.js
+++ b/script.js
@@ -95,43 +95,49 @@ async function handleSync(
   const wrapper = button.parentElement;
   const spinner = wrapper.querySelector('.spinner');
   const status = wrapper.querySelector('.status');
-  
+
   button.disabled = true;
   button.classList.add(DISABLED);
   spinner.style.display = 'inline-block';
   status.textContent = SYNC_IN_PROGRESS;
 
-  if(button.id === "sync-users-status") {
+  if (button.id === 'sync-users-status') {
     try {
       const userStatus = fetch(`${API_BASE_URL}${endpoint.userStatusUpdate}`, {
         method: method.userStatusMethod,
         credentials: 'include',
       });
-      
+
       const idleUsers = fetch(`${API_BASE_URL}${endpoint.idle}`, {
         method: method.idleMethod,
         credentials: 'include',
       })
-      .then((res) => res.json())
-      .then((data) => data.data.users)
+        .then((res) => res.json())
+        .then((data) => data.data.users);
 
-      const [ userStatusResponse, idleUsersData ] = await Promise.all([ userStatus, idleUsers ]);
+      const [userStatusResponse, idleUsersData] = await Promise.all([
+        userStatus,
+        idleUsers,
+      ]);
 
-      const batchResponse = await fetch(`${API_BASE_URL}${endpoint.batchIdle}`, {
-        headers: {
-          'Content-Type': 'application/json'
+      const batchResponse = await fetch(
+        `${API_BASE_URL}${endpoint.batchIdle}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: method.batchIdleMethod,
+          body: JSON.stringify({ users: idleUsersData }),
+          credentials: 'include',
         },
-        method: method.batchIdleMethod,
-        body: JSON.stringify({ users: idleUsersData }),
-        credentials: 'include'
-      })
+      );
 
       if (userStatusResponse.ok && batchResponse.ok) {
         status.textContent = SYNC_SUCCESSFUL;
         const lastSyncTimestamp = getCurrentTimestamp();
-  
+
         localStorage.setItem(localStorageKey, lastSyncTimestamp);
-  
+
         if (lastSyncElement) {
           lastSyncElement.textContent = `Last Sync: ${lastSyncTimestamp}`;
         }
@@ -146,20 +152,19 @@ async function handleSync(
       button.classList.remove(DISABLED);
       button.disabled = false;
     }
-
   } else {
     try {
       const response = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: method,
         credentials: 'include',
       });
-  
+
       if (response.ok) {
         status.textContent = SYNC_SUCCESSFUL;
         const lastSyncTimestamp = getCurrentTimestamp();
-  
+
         localStorage.setItem(localStorageKey, lastSyncTimestamp);
-  
+
         if (lastSyncElement) {
           lastSyncElement.textContent = `Last Sync: ${lastSyncTimestamp}`;
         }
@@ -247,14 +252,14 @@ addClickEventListener(
   {
     idle: '/users/status?aggregate=true',
     batchIdle: '/users/status/batch',
-    userStatusUpdate: '/users/status/update'
+    userStatusUpdate: '/users/status/update',
   },
   'lastSyncUsersStatus',
   syncUsersStatusUpdate,
   {
     idleMethod: 'GET',
     batchIdleMethod: 'PATCH',
-    userStatusMethod: 'PATCH'
+    userStatusMethod: 'PATCH',
   },
 );
 addClickEventListener(


### PR DESCRIPTION
**Issue :-** https://github.com/Real-Dev-Squad/website-dashboard/issues/433

**What is change?**
- The superuser should be able to run two more API on synceUserStatus button and those API which are not
- Also change the button positioning

Before :-
![Dashboard _ Real Dev Squad - Google Chrome 04-08-2023 12_37_03](https://github.com/Real-Dev-Squad/website-dashboard/assets/22213872/59af288a-98ae-4499-b271-650b71664d79)

After :-
![New Tab - Google Chrome 04-08-2023 12_38_42](https://github.com/Real-Dev-Squad/website-dashboard/assets/22213872/d3d07a67-53be-4297-8a2c-f58ca8ccaa0a)

Running two API concurrently who are non-dependent to save time :-
![Dashboard _ Real Dev Squad - Google Chrome 04-08-2023 12_40_05](https://github.com/Real-Dev-Squad/website-dashboard/assets/22213872/1bd8ad83-f5f0-4986-a6e4-8635002cdace)

Test Coverage :-

![package json - website-dashboard - Visual Studio Code 07-08-2023 04_11_40 (2)](https://github.com/Real-Dev-Squad/website-dashboard/assets/22213872/b2de2fb4-2b78-4b61-864d-360a011ab222)

