### PR TITLE
Show Previous 3 Months Data For Standup data 

### DIFF
--- a/__tests__/standup/standup.test.js
+++ b/__tests__/standup/standup.test.js
@@ -3,6 +3,36 @@ const API_BASE_URL = 'https://staging-api.realdevsquad.com';
 const { user } = require('../../mock-data/users');
 const { standup } = require('../../mock-data/standup');
 
+const oneDay = 24 * 60 * 60 * 1000;
+const numberOfMonthsAgo = 3;
+const currentDateObj = new Date();
+const currentYearNum = currentDateObj.getFullYear();
+const currentMonthNum = currentDateObj.getMonth();
+const endDate = currentDateObj;
+const startDate = new Date(
+  currentYearNum,
+  currentMonthNum - numberOfMonthsAgo,
+  1,
+);
+
+function isSunday(date) {
+  return date.getDay() === 0;
+}
+
+function generateExpectedDateValues() {
+  const expectedDateValues = [];
+  for (
+    let date = new Date(endDate);
+    date >= startDate;
+    date = new Date(date.getTime() - oneDay)
+  ) {
+    if (!isSunday(date)) {
+      expectedDateValues.push(date);
+    }
+  }
+  return expectedDateValues;
+}
+
 describe('Standup Page', () => {
   let browser;
   let page;
@@ -26,6 +56,7 @@ describe('Standup Page', () => {
         interceptedRequest.respond({
           status: 200,
           contentType: 'application/json',
+
           headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
@@ -114,5 +145,15 @@ describe('Standup Page', () => {
     await page.waitForTimeout(1000);
     const updatedUrl = page.url();
     expect(updatedUrl).toContain('q=user:sunny+user:pratiyush');
+  });
+
+  it('should display the correct date range in the table header', async () => {
+    const dateCellValues = await page.evaluate(() => {
+      const dateCells = Array.from(document.querySelectorAll('.dates'));
+      return dateCells.map((cell) => cell.textContent.trim());
+    });
+    const expectedDateValues = generateExpectedDateValues();
+    console.log('expected ', expectedDateValues);
+    expect(dateCellValues.length).toEqual(expectedDateValues.length);
   });
 });

--- a/__tests__/standup/standup.test.js
+++ b/__tests__/standup/standup.test.js
@@ -153,7 +153,6 @@ describe('Standup Page', () => {
       return dateCells.map((cell) => cell.textContent.trim());
     });
     const expectedDateValues = generateExpectedDateValues();
-    console.log('expected ', expectedDateValues);
     expect(dateCellValues.length).toEqual(expectedDateValues.length);
   });
 });

--- a/standup/script.js
+++ b/standup/script.js
@@ -15,7 +15,7 @@ const daysInCurrentMonth = new Date(
 ).getDate();
 const numberOfMonthsAgo = 3;
 function isSunday(date) {
-  return date.getDay() === 0; // 0 represents Sunday
+  return date.getDay() === 0;
 }
 const currentMonthNum = currentDateObj.getMonth();
 
@@ -24,7 +24,7 @@ const startDate = new Date(
   currentYearNum,
   currentMonthNum - numberOfMonthsAgo,
   1,
-); // Start from 3 months ago
+);
 
 function formatDateFromTimestamp(timestamp) {
   const dateObject = new Date(timestamp);

--- a/standup/script.js
+++ b/standup/script.js
@@ -8,38 +8,21 @@ const loaderElement = createLoaderElement();
 
 const currentDateObj = new Date();
 const currentYearNum = currentDateObj.getFullYear();
-const daysInCurrentMonth = new Date(
-  currentYearNum,
-  currentDateObj.getMonth() + 1,
-  0,
-).getDate();
+
 const numberOfMonthsAgo = 3;
 function isSunday(date) {
   return date.getDay() === 0;
 }
+
 const currentMonthNum = currentDateObj.getMonth();
 
+const oneDay = 24 * 60 * 60 * 1000;
 const endDate = currentDateObj;
 const startDate = new Date(
   currentYearNum,
   currentMonthNum - numberOfMonthsAgo,
   1,
 );
-
-function formatDateFromTimestamp(timestamp) {
-  const dateObject = new Date(timestamp);
-  const year = dateObject.getFullYear();
-  const month = dateObject.getMonth() + 1;
-  const day = dateObject.getDate();
-  return `${day}-${month}-${year}`;
-}
-
-function formatDate(dateObject) {
-  const year = dateObject.getFullYear();
-  const month = dateObject.getMonth() + 1;
-  const day = dateObject.getDate();
-  return `${day}-${month}-${year}`;
-}
 
 async function fetchUserData(username) {
   const response = await makeApiCall(`${RDS_API_USERS}/${username}`);
@@ -52,7 +35,7 @@ async function fetchStandupData(userId) {
   const data = await response.json();
   return data.data;
 }
-const oneDay = 24 * 60 * 60 * 1000;
+
 function processStandupData(standupItems) {
   const standupData = {
     standupFrequency: [],
@@ -148,13 +131,14 @@ function createTableHeaderElement() {
     if (!isSunday(date)) {
       const dateCellElement = createElement({
         type: 'th',
-        classList: ['date'],
+        classList: ['dates'],
         scope: 'row',
       });
-      dateCellElement.textContent = `${date.getDate()} ${date.toLocaleString(
-        'default',
-        { month: 'long' },
-      )} ${date.getFullYear()}`;
+      dateCellElement.textContent = `${getDayOfWeek(
+        date,
+      )} ${date.getDate()} ${date.toLocaleString('default', {
+        month: 'long',
+      })} ${date.getFullYear()}`;
       headerRowElement.appendChild(dateCellElement);
     }
   }
@@ -277,6 +261,7 @@ function createTableRowElement({ userName, imageUrl, userStandupData }) {
 
 function setupTable() {
   const tableHeaderElement = createTableHeaderElement();
+  tableBodyElement.classList.add('tableheader');
   tableElement.appendChild(tableHeaderElement);
   tableElement.appendChild(tableBodyElement);
   tableContainerElement.innerHTML = '';

--- a/standup/script.js
+++ b/standup/script.js
@@ -13,14 +13,18 @@ const daysInCurrentMonth = new Date(
   currentDateObj.getMonth() + 1,
   0,
 ).getDate();
-
+const numberOfMonthsAgo = 3;
 function isSunday(date) {
   return date.getDay() === 0; // 0 represents Sunday
 }
 const currentMonthNum = currentDateObj.getMonth();
 
 const endDate = currentDateObj;
-const startDate = new Date(currentYearNum, currentMonthNum - 3, 1); // Start from 3 months ago
+const startDate = new Date(
+  currentYearNum,
+  currentMonthNum - numberOfMonthsAgo,
+  1,
+); // Start from 3 months ago
 
 function formatDateFromTimestamp(timestamp) {
   const dateObject = new Date(timestamp);
@@ -71,7 +75,6 @@ function processStandupData(standupItems) {
         standupData.completedText.push('No data');
         standupData.plannedText.push('No data');
         standupData.blockersText.push('No data');
-        //${date.getDate()} ${date.toLocaleString('default', {month: 'long',})} ${date.getFullYear()}
         standupData.date.push(date.getDate());
         standupData.month.push(
           date.toLocaleString('default', { month: 'long' }),

--- a/standup/style.css
+++ b/standup/style.css
@@ -128,7 +128,8 @@ body {
   border: 1px solid var(--black-color);
 }
 
-.date {
+.date,
+.dates {
   position: sticky;
   top: 0;
   padding: 1rem;

--- a/standup/style.css
+++ b/standup/style.css
@@ -137,6 +137,7 @@ body {
   color: var(--white-color);
   z-index: 10;
   border: 1px solid var(--black-color);
+  min-width: 6rem;
 }
 
 .status {

--- a/standup/utils.js
+++ b/standup/utils.js
@@ -78,3 +78,33 @@ function createSidebarPanelElement(
   sidebarPanelElement.appendChild(blockersElement);
   return sidebarPanelElement;
 }
+
+function formatDateFromTimestamp(timestamp) {
+  const dateObject = new Date(timestamp);
+  const year = dateObject.getFullYear();
+  const month = dateObject.getMonth() + 1;
+  const day = dateObject.getDate();
+  return `${day}-${month}-${year}`;
+}
+
+function formatDate(dateObject) {
+  const year = dateObject.getFullYear();
+  const month = dateObject.getMonth() + 1;
+  const day = dateObject.getDate();
+  return `${day}-${month}-${year}`;
+}
+
+function getDayOfWeek(date) {
+  const daysOfWeek = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+  const dayIndex = date.getDay();
+
+  return daysOfWeek[dayIndex];
+}


### PR DESCRIPTION
closes https://github.com/Real-Dev-Squad/website-dashboard/issues/428 
Description:
The standup page currently fetches and displays data for the current month only. It uses a table to present the standup data of users, showing their daily progress throughout the current month.
However we show show dates chronologically from current date till 2 months back in a reverse order while skipping Sundays

demo:

https://github.com/Real-Dev-Squad/website-dashboard/assets/22434603/41fc74f4-848b-405f-bb60-7b25606c3917


![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/22434603/91e76d6a-1440-4e75-85f8-add1f0647b4c)



test coverage
![testcoverage](https://github.com/Real-Dev-Squad/website-dashboard/assets/22434603/ad15da8d-e38e-4157-bdd0-a39280f55909)


