### PR TITLE
moving the use of modified GET discord-actions/groups api under feature flag

### DIFF
--- a/__tests__/groups/group.test.js
+++ b/__tests__/groups/group.test.js
@@ -1,6 +1,5 @@
 const puppeteer = require('puppeteer');
 const { allUsersData } = require('../../mock-data/users');
-const { API_BASE_URL } = require('../../constants');
 const { discordGroups } = require('../../mock-data/groups');
 
 const BASE_URL = 'https://api.realdevsquad.com';
@@ -225,7 +224,7 @@ describe('Discord Groups Page', () => {
     expect(creatorImageSrcAndAltText).toEqual(expectedImageSrcAndAltText);
   });
 
-  test("should show proper group creator's image", async () => {
+  test("should show proper group creator's name", async () => {
     const createdByLines = await page.$$eval('.created-by', (elements) => {
       return elements.map((element) => element.innerText);
     });

--- a/groups/constants.js
+++ b/groups/constants.js
@@ -1,4 +1,5 @@
 const NO_SPACES_ALLOWED = 'Roles cannot have spaces';
 const CANNOT_CONTAIN_GROUP = "Roles cannot contain 'group'.";
+const DEV_FEATURE_FLAG = 'dev';
 
-export { NO_SPACES_ALLOWED, CANNOT_CONTAIN_GROUP };
+export { NO_SPACES_ALLOWED, CANNOT_CONTAIN_GROUP, DEV_FEATURE_FLAG };

--- a/groups/script.js
+++ b/groups/script.js
@@ -13,6 +13,8 @@ const sections = document.querySelectorAll('.manage-groups, .create-group');
 const loader = document.querySelector('.backdrop');
 const userIsNotVerifiedText = document.querySelector('.not-verified-tag');
 const userSelfData = await getUserSelf();
+const params = new URLSearchParams(window.location.search);
+const isDev = params.get('dev');
 
 /**
  * Create DOM for "created by author" line under groupName
@@ -52,7 +54,7 @@ const memberAddRoleBody = {
  *
  * FOR RENDERING GROUP ROLES IN 'MANAGE ROLES' TAB
  */
-const groupsData = await getDiscordGroups();
+const groupsData = await getDiscordGroups(isDev);
 const groupRoles = document.querySelector('.groups-list');
 groupsData?.forEach((item) => {
   const group = document.createElement('li');
@@ -116,7 +118,7 @@ groupRoles?.addEventListener('click', function (event) {
   if (groupListItem) {
     const newURL = `${window.location.pathname}?${
       groupListItem.querySelector('p').textContent
-    }`;
+    }${isDev ? '&dev=true' : ''}`;
     window.history.pushState({}, '', newURL);
     groupListItem.classList.add('active-group');
     memberAddRoleBody.roleid = groupListItem.id;

--- a/groups/script.js
+++ b/groups/script.js
@@ -14,7 +14,7 @@ const loader = document.querySelector('.backdrop');
 const userIsNotVerifiedText = document.querySelector('.not-verified-tag');
 const userSelfData = await getUserSelf();
 const params = new URLSearchParams(window.location.search);
-const isDev = params.get('dev');
+const isDev = params.get('dev') === 'true';
 
 /**
  * Create DOM for "created by author" line under groupName

--- a/groups/script.js
+++ b/groups/script.js
@@ -69,7 +69,11 @@ groupsData?.forEach((item) => {
   const group = document.createElement('li');
   group.setAttribute('id', item.roleid);
   group.classList.add('group-role');
-  if (window.location.search.slice(1) === item.rolename) {
+  const formattedRoleName = removeGroupKeywordFromDiscordRoleName(
+    item.rolename,
+  );
+
+  if (params.has(formattedRoleName)) {
     group.classList.add('active-group');
   }
 
@@ -81,7 +85,7 @@ groupsData?.forEach((item) => {
     groupname.setAttribute('data-member-count', item.memberCount);
   }
 
-  groupname.textContent = removeGroupKeywordFromDiscordRoleName(item.rolename);
+  groupname.textContent = formattedRoleName;
 
   const createdBy = createAuthorDetailsDOM(
     item.firstName,
@@ -130,9 +134,8 @@ groupRoles?.addEventListener('click', function (event) {
   const groupListItem = event.target?.closest('li');
   if (groupListItem) {
     const devFeatureFlag = isDev ? '&dev=true' : '';
-    const newURL = `${window.location.pathname}?${
-      groupListItem.querySelector('p').textContent
-    }${devFeatureFlag}`;
+    const rolename = `${groupListItem.querySelector('p').textContent}`;
+    const newURL = `${window.location.pathname}?${rolename}${devFeatureFlag}`;
     window.history.pushState({}, '', newURL);
     groupListItem.classList.add('active-group');
     memberAddRoleBody.roleid = groupListItem.id;

--- a/groups/style.css
+++ b/groups/style.css
@@ -112,6 +112,7 @@
   border: 1px solid var(--color-list-border);
   margin-bottom: 0.6rem;
   border-radius: 0.6rem;
+  min-width: 12rem;
 }
 .groups-list li:hover {
   cursor: pointer;
@@ -127,6 +128,10 @@
   margin: auto 0.26rem;
   font-size: 0.8rem;
   color: var(--color-member-count);
+}
+
+.group-name:not([data-member-count])::after {
+  display: none;
 }
 
 .created-by--container {

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -34,8 +34,9 @@ async function getUserSelf() {
 }
 async function getDiscordGroups(isDev) {
   try {
+    const devFeatureFlag = isDev ? '?dev=true' : '';
     const res = await fetch(
-      `${BASE_URL}/discord-actions/groups${isDev ? '?dev=true' : ''}`,
+      `${BASE_URL}/discord-actions/groups${devFeatureFlag}`,
       {
         method: 'GET',
         credentials: 'include',

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -32,15 +32,18 @@ async function getUserSelf() {
     return err;
   }
 }
-async function getDiscordGroups() {
+async function getDiscordGroups(isDev) {
   try {
-    const res = await fetch(`${BASE_URL}/discord-actions/groups`, {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        'Content-type': 'application/json',
+    const res = await fetch(
+      `${BASE_URL}/discord-actions/groups${isDev ? '?dev=true' : ''}`,
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-type': 'application/json',
+        },
       },
-    });
+    );
 
     const { groups } = await res.json();
     return groups;


### PR DESCRIPTION
### Description
This pull request aims to address the issue of discrepancies between the `GET discord-actions/groups` API in STAGING and PROD environments. Currently, the API is functioning correctly on STAGING, but it returns an Internal Server Error on PROD. While the exact root cause is still under investigation, there is a consensus that the issue might be related to stale data in the PROD environment.
Fixes: #450 

#### Proposed Solution
To resolve this issue and ensure a controlled testing and debugging process, a feature flag mechanism is being introduced to the GET discord-actions/groups API. This feature flag will allow the gradual release of new changes to the API on different environments while maintaining stability in the existing functionality.

### Changes
The changes utilize the `dev=true` flag from the URL and subsequently pass this flag to the API. Depending on the value of this flag, the API will generate a list of groups, adjusting whether additional membership data is included in the response or not.

### Screenshots
#### Before
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/27444637/464e800e-db92-4b89-bea3-31bafc7e03e2)

#### After

##### Without flag 
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/27444637/c26316e4-971a-41e5-9347-87297e8ea96f)


##### With flag (dev=true)
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/27444637/1f1abd3a-c8cf-4047-9ddf-125d8b939141)


### Demo Video

https://github.com/Real-Dev-Squad/website-dashboard/assets/27444637/a509a093-40fd-44d5-97cb-d4dd7c4b484e



 


