### PR TITLE
Fix failing puppeteer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jsdom": "^21.1.1",
     "pre-commit": "^1.2.2",
     "prettier": "2.3.1",
-    "puppeteer": "^21.1.1",
+    "puppeteer": "^20.2.1",
     "puppeteer-core": "^19.9.0"
   },
   "volta": {


### PR DESCRIPTION
Reverts the puppeteer version to 20.2.1 which is compatible with node v14. 