### PR TITLE
Toggle add and remove button functionality according user group data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "liveServer.settings.port": 5501
-}

--- a/__tests__/groups/group.test.js
+++ b/__tests__/groups/group.test.js
@@ -62,6 +62,17 @@ describe('Discord Groups Page', () => {
             },
             body: JSON.stringify(discordGroups),
           });
+        } else if (url === `${BASE_URL}/discord-actions/groups?dev=true`) {
+          interceptedRequest.respond({
+            status: 200,
+            contentType: 'application/json',
+            headers: {
+              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+              'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            },
+            body: JSON.stringify(discordGroups),
+          });
         } else if (url === `${BASE_URL}/discord-actions/roles`) {
           interceptedRequest.respond({
             status: 200,
@@ -169,6 +180,9 @@ describe('Discord Groups Page', () => {
   });
 
   test('Should show add button as user not part of the group', async () => {
+    await page.goto('http://localhost:8000/groups/?dev=true');
+    await page.waitForNetworkIdle();
+
     const group = await page.$('.group-role');
     await group.click();
 
@@ -242,7 +256,7 @@ describe('Discord Groups Page', () => {
         element.getAttribute('data-member-count'),
       );
     });
-    expect(memberCounts).toEqual(['4', '200', '0']);
+    expect(memberCounts).toEqual(['3', '200', '0']);
   });
 
   test("should show proper group creator's image", async () => {

--- a/groups/script.js
+++ b/groups/script.js
@@ -244,6 +244,8 @@ async function addrole() {
  */
 async function removeRoleHandler() {
   console.log('Remove function to be added after this pr');
+
+  // TODO: REMOVE ME BUTTON FUNCTIONALITY TO BE ADDED
 }
 
 /**

--- a/groups/script.js
+++ b/groups/script.js
@@ -148,7 +148,13 @@ groupRoles?.addEventListener('click', function (event) {
     groupListItem.classList.add('active-group');
     memberAddRoleBody.roleid = groupListItem.id;
     if (IsUserVerified) {
-      updateButtonState();
+      if (isDev) {
+        buttonAddRole.removeEventListener('click', addrole);
+        updateButtonState();
+      } else {
+        buttonAddRole.disabled = false;
+        buttonAddRole.addEventListener('click', addrole);
+      }
     }
   }
 });
@@ -218,12 +224,13 @@ async function addrole() {
         groupNameElement.setAttribute('data-member-count', +currentCount + 1);
       }
       alert(res.message);
+      if (isDev) {
+        // After adding the role, re-fetch the user group data to update it
+        UserGroupData = await getUserGroupRoles();
 
-      // After adding the role, re-fetch the user group data to update it
-      UserGroupData = await getUserGroupRoles();
-
-      // Update the button state with the refreshed data
-      updateButtonState();
+        // Update the button state with the refreshed data
+        updateButtonState();
+      }
     } catch (err) {
       alert(err.message);
     } finally {

--- a/groups/script.js
+++ b/groups/script.js
@@ -10,15 +10,19 @@ import {
   addGroupRoleToMember,
   createDiscordGroupRole,
   getUserSelf,
+  getUserGroupRoles,
 } from './utils.js';
 const groupTabs = document.querySelector('.groups-tab');
 const tabs = document.querySelectorAll('.groups-tab div');
 const sections = document.querySelectorAll('.manage-groups, .create-group');
 const loader = document.querySelector('.backdrop');
 const userIsNotVerifiedText = document.querySelector('.not-verified-tag');
-const userSelfData = await getUserSelf();
 const params = new URLSearchParams(window.location.search);
 const isDev = params.get(DEV_FEATURE_FLAG) === 'true';
+
+//User Data
+const userSelfData = await getUserSelf();
+let UserGroupData = await getUserGroupRoles();
 
 /**
  * Create DOM for "created by author" line under groupName
@@ -120,6 +124,10 @@ groupTabs.addEventListener('click', (e) => {
   });
   if (e.target.nodeName !== 'NAV') e.target?.classList?.add('active-tab');
 });
+function isRoleIdInData(data, targetRoleId) {
+  // Use the some() method to check if any element in data.groups has a matching roleId
+  return data.groups.some((group) => group.roleId === targetRoleId);
+}
 
 /**
  * FOR SELECTING A GROUP
@@ -140,11 +148,27 @@ groupRoles?.addEventListener('click', function (event) {
     groupListItem.classList.add('active-group');
     memberAddRoleBody.roleid = groupListItem.id;
     if (IsUserVerified) {
-      buttonAddRole.disabled = false;
+      updateButtonState();
     }
   }
 });
+// Function to update the button state based on user's group roles
+function updateButtonState() {
+  const isRoleIdPresent = isRoleIdInData(
+    UserGroupData,
+    memberAddRoleBody.roleid,
+  );
+  buttonAddRole.textContent = isRoleIdPresent
+    ? 'Remove me from this group'
+    : 'Add me to this group';
+  buttonAddRole.disabled = false;
 
+  isRoleIdPresent
+    ? (buttonAddRole.removeEventListener('click', addrole),
+      buttonAddRole.addEventListener('click', removeRoleHandler))
+    : (buttonAddRole.removeEventListener('click', removeRoleHandler),
+      buttonAddRole.addEventListener('click', addrole));
+}
 // const paragraphElement = null, paragraphContent = '';
 const searchInput = document.getElementById('search-groups');
 
@@ -178,25 +202,42 @@ searchInput.addEventListener('keyup', () => {
  * TO ASSIGN YOURSELF A ROLE
  */
 const buttonAddRole = document.querySelector('.btn-add-role');
-buttonAddRole.addEventListener('click', async function () {
+async function addrole() {
   if (memberAddRoleBody?.userid && memberAddRoleBody?.roleid !== '') {
     loader.classList.remove('hidden');
 
-    addGroupRoleToMember(memberAddRoleBody)
-      .then((res) => {
-        const groupNameElement = document.getElementById(
-          `name-${memberAddRoleBody.roleid}`,
-        );
-        const currentCount = groupNameElement.getAttribute('data-member-count');
-        if (currentCount !== null && currentCount !== undefined) {
-          groupNameElement.setAttribute('data-member-count', +currentCount + 1);
-        }
-        alert(res.message);
-      })
-      .catch((err) => alert(err.message))
-      .finally(() => loader.classList.add('hidden'));
+    try {
+      // Add the role to the member
+      const res = await addGroupRoleToMember(memberAddRoleBody);
+
+      const groupNameElement = document.getElementById(
+        `name-${memberAddRoleBody.roleid}`,
+      );
+      const currentCount = groupNameElement.getAttribute('data-member-count');
+      if (currentCount !== null && currentCount !== undefined) {
+        groupNameElement.setAttribute('data-member-count', +currentCount + 1);
+      }
+      alert(res.message);
+
+      // After adding the role, re-fetch the user group data to update it
+      UserGroupData = await getUserGroupRoles();
+
+      // Update the button state with the refreshed data
+      updateButtonState();
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      loader.classList.add('hidden');
+    }
   }
-});
+}
+
+/**
+ * TO REMOVE YOURSELF OF A ROLE
+ */
+async function removeRoleHandler() {
+  console.log('Remove function to be added after this pr');
+}
 
 /**
  *

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -32,6 +32,17 @@ async function getUserSelf() {
     return err;
   }
 }
+async function getUserGroupRoles() {
+  const res = await fetch(`${BASE_URL}/discord-actions/roles`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+  return await res.json();
+}
+
 async function getDiscordGroups(isDev) {
   try {
     const devFeatureFlag = isDev ? '?dev=true' : '';
@@ -103,6 +114,7 @@ function removeGroupKeywordFromDiscordRoleName(groupName) {
 }
 
 export {
+  getUserGroupRoles,
   getMembers,
   getUserSelf,
   getDiscordGroups,

--- a/mock-data/groups/index.js
+++ b/mock-data/groups/index.js
@@ -46,4 +46,29 @@ const discordGroups = {
   ],
 };
 
-module.exports = { discordGroups };
+const GroupRoleData = {
+  message: 'User group roles Id fetched successfully!',
+  userId: '1234398439439989',
+  groups: [
+    {
+      roleId: '1103808103641780925',
+    },
+    {
+      roleId: '1151598744278667264',
+    },
+    {
+      roleId: '1151808031613521951',
+    },
+    {
+      roleId: '1122182070509244416',
+    },
+    {
+      roleId: '1151807937149419531',
+    },
+    {
+      roleId: '1151598712573939792',
+    },
+  ],
+};
+
+module.exports = { discordGroups, GroupRoleData };


### PR DESCRIPTION
## Overview of the task:
**It toggles the visibility and functionality of the add and remove button on the dashboard site group section. If a user is already in a group remove button to be shown and if a user is not in a group add button to be shown on the site**

## Closes Open Issue
- #424
## Feature flag demo
[Screencast from 16-09-23 11:23:27 PM IST.webm](https://github.com/Real-Dev-Squad/website-dashboard/assets/48379860/e1ab44cf-946d-424b-9b3d-91031d69a2bb)


## Demo video
[Screencast from 15-09-23 12:24:19 AM IST.webm](https://github.com/Real-Dev-Squad/website-dashboard/assets/48379860/eab1505a-9b91-4760-9532-3d5d64b7dd50)

## Test Coverage
![Screenshot from 2023-09-16 16-58-49](https://github.com/Real-Dev-Squad/website-dashboard/assets/48379860/e37472bc-70e8-49af-96e1-ad0525195d53)


## Note
Remove functionality of the button to remove yourself from the group to be added after this pr for now only UI part has been added as I have divided my task into different issues
## Part of meta issue  : 
- #482 

