### PR TITLE
Filtering Fixed For Onboarding > 31 feature

### DIFF
--- a/__tests__/users/onboarding-31-days-multiple-selections.test.js
+++ b/__tests__/users/onboarding-31-days-multiple-selections.test.js
@@ -1,0 +1,143 @@
+const puppeteer = require('puppeteer');
+
+describe('Tests the "Onboarding > 31 Days" Filter', () => {
+  let browser;
+  let page;
+
+  jest.setTimeout(60000);
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new', //change headless to 'new' to check the tests in browser
+      ignoreHTTPSErrors: true,
+      args: ['--incognito', '--disable-web-security'],
+      devtools: false,
+    });
+    page = await browser.newPage();
+
+    await page.setRequestInterception(true);
+
+    page.on('request', (interceptedRequest) => {
+      const url = interceptedRequest.url();
+      if (url === 'https://api.realdevsquad.com/tasks/sunny-s') {
+        // When we encounter the respective api call we respond with the below response
+        interceptedRequest.respond({
+          status: 200,
+          contentType: 'application/json',
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          },
+          body: JSON.stringify(userDetailsApi),
+        });
+      } else if (url === 'https://api.realdevsquad.com/users/self') {
+        // When we encounter the respective api call we respond with the below response
+        interceptedRequest.respond({
+          status: 200,
+          contentType: 'application/json',
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          },
+          body: JSON.stringify(superUserDetails), // Y contains the json of a superuser in the server which will grant us the access to view the page without locks
+        });
+      } else {
+        interceptedRequest.continue();
+      }
+    });
+    await page.goto('http://localhost:8000/users/?dev=true');
+
+    await page.waitForNetworkIdle();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('should gives results for Onboarding > 31 SELECTED', async () => {
+    const taskDiv = await page.$('.filter-button');
+    expect(taskDiv).toBeTruthy();
+
+    await taskDiv.click();
+
+    await page.waitForTimeout(2000);
+    const elements = await page.$$('.checkbox-label');
+
+    // Checking if elements are found
+    expect(elements).toBeTruthy();
+
+    const checkbox = await page.$('#ONBOARDING31DAYS');
+    await checkbox.click();
+
+    const applyfilterbutton = await page.$('.apply-filter-button');
+    expect(applyfilterbutton).toBeTruthy();
+    await applyfilterbutton.click();
+
+    await page.waitForTimeout(500);
+  });
+  it('should gives results for ACTIVE SELECTED', async () => {
+    const taskDiv = await page.$('.filter-button');
+    expect(taskDiv).toBeTruthy();
+
+    await taskDiv.click();
+
+    // await page.waitForTimeout(2000);  enable to see the tests in actions
+    const elements = await page.$$('.checkbox-label');
+
+    const clear = await page.$('#clear-button');
+    await clear.click();
+
+    // await page.waitForTimeout(2000);     enable to see the tests in actions
+
+    const taskDiv2 = await page.$('.filter-button');
+    await taskDiv2.click();
+    expect(taskDiv2).toBeTruthy();
+    // await page.waitForTimeout(2000); enable to see the tests in actions
+    expect(elements).toBeTruthy();
+
+    const checkbox = await page.$('#ACTIVE');
+    await checkbox.click();
+
+    const applyfilterbutton = await page.$('.apply-filter-button');
+    expect(applyfilterbutton).toBeTruthy();
+    await applyfilterbutton.click();
+
+    await page.waitForTimeout(500);
+  });
+
+  it('should gives results for both ACTIVE & Onboarding > 31 SELECTED', async () => {
+    const taskDiv = await page.$('.filter-button');
+    expect(taskDiv).toBeTruthy();
+
+    await taskDiv.click();
+
+    // await page.waitForTimeout(2000);  enable to see the tests in actions
+    const elements = await page.$$('.checkbox-label');
+
+    // Checking if elements are found
+    expect(elements).toBeTruthy();
+
+    const clear = await page.$('#clear-button');
+    await clear.click();
+
+    // await page.waitForTimeout(2000);   enable to see the tests in actions
+
+    const taskDiv2 = await page.$('.filter-button');
+    await taskDiv2.click();
+    expect(taskDiv2).toBeTruthy();
+    // await page.waitForTimeout(2000);  enable to see the tests in actions
+    const checkbox = await page.$('#ONBOARDING31DAYS');
+    await checkbox.click();
+    // await page.waitForTimeout(2000);  enable to see the tests in actions
+    const checkbox2 = await page.$('#ACTIVE');
+    await checkbox2.click();
+    // await page.waitForTimeout(2000);   enable to see the tests in actions
+    const applyfilterbutton = await page.$('.apply-filter-button');
+    expect(applyfilterbutton).toBeTruthy();
+    await applyfilterbutton.click();
+
+    await page.waitForTimeout(500);
+  });
+});


### PR DESCRIPTION
Hello,

This is a fix for issue #511, the issue ticket says that it is a backend issue but after carefully reviewing the code with the creator, the problem was found in the front end.

While writing the code we did not consider the case where we select multiple checkboxes. The code only covered the part where the checkbox for "onboarding > 31 days" is checked. Look at the below images for a better understanding.

**Image 1:** Working of the current page when 'onboarding>31' is **NOT** selected.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/31709147/b61fc526-f395-4971-be90-a37a9758365d)

**Image 2:** Working of the page when 'onboarding>31' **is** selected. It sends a wrong API call.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/31709147/0b98baf1-1a42-4fad-af22-233b2a07bbff)

Only adding the other cases in the code was not enough, as after refreshing the page we ran into one more issue.

I had to write a function to change the query parameters if the onboarding>31 checkbox is checked. The function returns the 
updated query parameters so that the right API call is made.

Post making the required changes, we can see the right API calls being made.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/31709147/034884fe-1d29-4ce5-902d-fccbe779743a)


**TESTS:**
Tests are passing as we can see in the video below:

https://github.com/Real-Dev-Squad/website-dashboard/assets/31709147/1a50b1fa-6e38-48f2-acd6-5d306cce572d




