### PR TITLE
feat: added sync onboarding 31 days plus users button

### DIFF
--- a/__tests__/home/home.test.js
+++ b/__tests__/home/home.test.js
@@ -29,8 +29,7 @@ describe('Home Page', () => {
           body: JSON.stringify(superUserData),
         });
       } else if (
-        url ===
-        `https://api.realdevsquad.com/discord-actions/nicknames/sync?dev=true`
+        url === `https://api.realdevsquad.com/discord-actions/group-idle-7d`
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -62,7 +61,8 @@ describe('Home Page', () => {
           }),
         });
       } else if (
-        url === `https://api.realdevsquad.com/discord-actions/group-idle-7d`
+        url ===
+        `https://api.realdevsquad.com/discord-actions/nicknames/sync?dev=true`
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -76,6 +76,74 @@ describe('Home Page', () => {
           body: JSON.stringify({
             numberOfUsersEffected: 5,
             message: 'Users Nicknames updated successfully',
+          }),
+        });
+      } else if (
+        url ===
+        `https://api.realdevsquad.com/discord-actions/group-onboarding-31d-plus`
+      ) {
+        interceptedRequest.respond({
+          status: 200,
+          ok: true,
+          contentType: 'application/json',
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          },
+          body: JSON.stringify({
+            message:
+              'All Users with 31 Days Plus Onboarding are updated successfully.',
+            totalOnboardingUsers31DaysCompleted: {
+              users: [
+                {
+                  userId: 'R4qppGmmAvJzQXI4jvuc',
+                  discordId: '799600467218923521',
+                  username: 'AnishPawaskar',
+                },
+                {
+                  userId: 'W7hqS6BJqWzNW2ejeimC',
+                  discordId: '700385688557715456',
+                  username: 'amandixit',
+                },
+              ],
+              count: 2,
+            },
+            totalUsersHavingNoDiscordId: 0,
+            totalArchivedUsers: 0,
+            usersAlreadyHavingOnboaring31DaysRole: {
+              users: [],
+              count: 0,
+            },
+            totalOnboarding31dPlusRoleApplied: {
+              count: 2,
+              response: [
+                {
+                  message: 'Role added successfully',
+                  discordId: '799600467218923521',
+                },
+                {
+                  message: 'Role added successfully',
+                  discordId: '700385688557715456',
+                },
+              ],
+            },
+            totalOnboarding31dPlusRoleNoteApplied: {
+              count: 0,
+              errors: [],
+            },
+            totalOnboarding31dPlusRoleRemoved: {
+              count: 0,
+              response: [],
+            },
+            totalOnboarding31dPlusRoleNotRemoved: {
+              count: 0,
+              errors: [],
+            },
+            errorInFetchingUserDetailsForRoleRemoval: {
+              count: 0,
+              errors: [],
+            },
           }),
         });
       } else {
@@ -317,5 +385,45 @@ describe('Home Page', () => {
 
     const repoLinkStyle = await page.evaluate((el) => el.style, repoLink);
     expect(repoLinkStyle).toBeTruthy();
+  });
+
+  it('should display the Sync Onboarding 31d+ button', async () => {
+    const syncOnboarding31dPlusUsersButton = await page.$(
+      '#sync-onboarding-31d-plus-users',
+    );
+    expect(syncOnboarding31dPlusUsersButton).toBeTruthy();
+
+    const spinnerInsideSyncOnboarding31dPlusUsers =
+      await syncOnboarding31dPlusUsersButton.$('.spinner');
+    expect(spinnerInsideSyncOnboarding31dPlusUsers).toBeTruthy();
+
+    const syncOnboarding31dPlusUsersUpdate = await page.$(
+      '#sync-onboarding-31d-plus-users-update',
+    );
+    expect(syncOnboarding31dPlusUsersUpdate).toBeTruthy();
+  });
+
+  it('should display the latest sync date when a super_user clicks on the  Sync Onboarding 31d+ button', async () => {
+    await page.evaluate(() => {
+      document.querySelector('#sync-onboarding-31d-plus-users').click();
+    });
+    await page.waitForNetworkIdle();
+
+    const latestSyncStatusElement = await page.waitForSelector(
+      '#sync-onboarding-31d-plus-users-update',
+    );
+
+    expect(latestSyncStatusElement).toBeTruthy();
+
+    const latestSyncStatusText = await page.evaluate(
+      (element) => element.textContent,
+      latestSyncStatusElement,
+    );
+
+    expect(latestSyncStatusText).not.toBe(`Last Sync: Failed`);
+    expect(latestSyncStatusText).not.toBe(
+      `Last Sync: Synced Data Not Available`,
+    );
+    expect(latestSyncStatusText).not.toBe(`Last Sync: In progress`);
   });
 });

--- a/constants.js
+++ b/constants.js
@@ -16,6 +16,9 @@ const SYNC_NICKNAMES = 'sync-nicknames';
 const SYNC_NICKNAMES_STATUS_UPDATE = 'sync-nicknames-status-update';
 const SYNC_IDLE_7D_Plus_USERS = 'sync-idle-7d-Plus-users';
 const SYNC_IDLE_7D_Plus_USERS_UPDATE = 'sync-idle-7d-Plus-users-update';
+const SYNC_ONBOARDING_31D_PLUS_USERS = 'sync-onboarding-31d-plus-users';
+const SYNC_ONBOARDING_31D_PLUS_USERS_UPDATE =
+  'sync-onboarding-31d-plus-users-update';
 const SYNC_IN_PROGRESS = 'Last Sync: In progress';
 const SYNC_SUCCESSFUL = 'Last Sync: Successful';
 const SYNC_FAILED = 'Last Sync: Failed';

--- a/index.html
+++ b/index.html
@@ -90,6 +90,14 @@
         </button>
         <div class="status" id="sync-nicknames-status-update"></div>
       </div>
+
+      <div class="button-container">
+        <button class="action-button" id="sync-onboarding-31d-plus-users">
+          <span class="spinner"></span>
+          Sync Onboarding 31d+ Users On Discord
+        </button>
+        <div class="status" id="sync-onboarding-31d-plus-users-update"></div>
+      </div>
     </section>
 
     <section class="buttonSection">

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
       <div class="button-container">
         <button class="action-button" id="sync-onboarding-31d-plus-users">
           <span class="spinner"></span>
-          Sync Onboarding 31d+ Users On Discord
+          Sync Onboarding 31d+ Users
         </button>
         <div class="status" id="sync-onboarding-31d-plus-users-update"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -31,6 +31,13 @@ const syncUnverifiedUsersUpdate = document.getElementById(
 );
 const buttonSection = document.getElementById('sync-buttons');
 
+const syncOnboarding31dPlusUsersButton = document.getElementById(
+  SYNC_ONBOARDING_31D_PLUS_USERS,
+);
+const syncOnboarding31dPlusUsersUpdate = document.getElementById(
+  SYNC_ONBOARDING_31D_PLUS_USERS_UPDATE,
+);
+
 function getCurrentTimestamp() {
   return new Date().toLocaleString();
 }
@@ -64,6 +71,10 @@ export async function showSuperUserOptions(...privateBtns) {
       }`;
       syncNicknamesStatusUpdate.textContent = `Last Sync: ${
         localStorage.getItem('lastSyncNicknames') || 'Synced Data Not Available'
+      }`;
+      syncOnboarding31dPlusUsersUpdate.textContent = `Last Sync: ${
+        localStorage.getItem('lastSyncOnboarding31dPlusUsers') ||
+        'Synced Data Not Available'
       }`;
     }
   } catch (err) {
@@ -332,5 +343,13 @@ addClickEventListener(
   '/discord-actions/group-idle-7d',
   'lastSyncIdle7dUsers',
   syncIdle7dUsersUpdate,
+  'PUT',
+);
+
+addClickEventListener(
+  syncOnboarding31dPlusUsersButton,
+  '/discord-actions/group-onboarding-31d-plus',
+  'lastSyncOnboarding31dPlusUsers',
+  syncOnboarding31dPlusUsersUpdate,
   'PUT',
 );


### PR DESCRIPTION
**Issue** - https://github.com/Real-Dev-Squad/website-dashboard/issues/539

**Changes** - A button is added to the dashboard site for SUPERUSER to run the API and sync the "group-onboarding-31d+" users.

**Demo** -
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/30263070/1d390a67-ff4b-474e-8d78-d8ebd172718a)


https://github.com/Real-Dev-Squad/website-dashboard/assets/30263070/aa46d6a0-600d-4e7e-868a-4ec7353235c0

**Test Coverage :**

![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/30263070/fcdd7690-6326-4e41-8c19-65d7de8f050d)
