### PR TITLE
User name and Image with dropdown options after sign in

### DIFF
--- a/__tests__/home/home.test.js
+++ b/__tests__/home/home.test.js
@@ -387,6 +387,57 @@ describe('Home Page', () => {
     expect(repoLinkStyle).toBeTruthy();
   });
 
+  it('Check user profile with dropdown options', async () => {
+    const DROPDOWN_OPTIONS = [
+      {
+        name: 'Home',
+        link: 'https://dashboard.realdevsquad.com/',
+      },
+      {
+        name: 'Status',
+        link: 'https://my.realdevsquad.com/',
+      },
+      {
+        name: 'Profile',
+        link: 'https://my.realdevsquad.com/profile',
+      },
+      {
+        name: 'Tasks',
+        link: 'https://my.realdevsquad.com/tasks',
+      },
+      {
+        name: 'Identity',
+        link: 'https://my.realdevsquad.com/identity',
+      },
+    ];
+
+    const userName = await page.$eval(
+      '#user-name',
+      (element) => element.textContent,
+    );
+    const userImage = await page.$eval('#user-img', (element) => element.src);
+    expect(userName).toContain(superUserData.first_name);
+    expect(userImage).toEqual(superUserData.picture.url);
+
+    const userInfoButton = await page.$('.user-info');
+    await userInfoButton.click();
+
+    const hrefs = await page.$$eval(
+      '.dropdown-list .dropdown-item a',
+      (elements) => elements.map((element) => element.getAttribute('href')),
+    );
+
+    const expectedHrefs = DROPDOWN_OPTIONS.map((option) => option.link);
+
+    expect(hrefs).toEqual(expectedHrefs);
+
+    const signoutButton = await page.$('#signout-option');
+    await signoutButton.click();
+    const signinButton = await page.$('.sign-in-btn');
+
+    expect(signinButton).toBeTruthy();
+  });
+
   it('should display the Sync Onboarding 31d+ button', async () => {
     const syncOnboarding31dPlusUsersButton = await page.$(
       '#sync-onboarding-31d-plus-users',

--- a/index.html
+++ b/index.html
@@ -37,9 +37,16 @@
         <a
           href="https://github.com/login/oauth/authorize?client_id=23c78f66ab7964e5ef97"
           >Sign In <span>With GitHub</span>
-          <img src="images/github.png" alt="" />
+          <img src="images/github.png" class="user-avatar" />
         </a>
       </div>
+      <div class="user-info">
+        <span id="user-name"></span>
+        <span>
+          <img id="user-img" src="" alt="" />
+        </span>
+      </div>
+      <div id="dropdown"></div>
     </nav>
 
     <section id="sync-buttons" class="element-display-remove">

--- a/mock-data/users/index.js
+++ b/mock-data/users/index.js
@@ -219,6 +219,10 @@ const superUserData = {
   twitter_id: 'Codesh_',
   first_name: 'Kotesh',
   username: 'kotesh',
+  picture: {
+    publicId: 'profile/w2XR9Gkid6Kg5xCJ5Elm/rzh3cwff7hh7srvg63mb',
+    url: 'https://res.cloudinary.com/realdevsquad/image/upload/v1692990078/profile/w2XR9Gkid6Kg5xCJ5Elm/rzh3cwff7hh7srvg63mb.png',
+  },
 };
 module.exports = {
   allUsersData,

--- a/script.js
+++ b/script.js
@@ -339,7 +339,6 @@ addClickEventListener(
   'POST',
 );
 
-
 const DROPDOWN_OPTIONS = [
   {
     name: 'Home',
@@ -438,7 +437,6 @@ async function handleUserSignin() {
   } catch (error) {}
 }
 handleUserSignin();
-
 
 addClickEventListener(
   syncIdle7dUsersButton,

--- a/style.css
+++ b/style.css
@@ -10,6 +10,8 @@
   --blue-color: #1d1283;
   --success-color: green;
   --failure-color: #f44336;
+  --lightblue-color: #0d6efd;
+  --lightgray-color: #d7d6d6;
 }
 
 body {
@@ -367,6 +369,77 @@ footer {
 .element-display-remove {
   display: none !important;
 }
+/* Dropdown container */
+
+#dropdown {
+  display: none;
+  position: absolute;
+  width: 9.5rem;
+  right: 1.5rem;
+  text-align: center;
+  top: 3rem;
+  z-index: 100;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0.63rem 0;
+  background-color: var(--white-color);
+  border-radius: 0.63rem;
+  font-size: 0.75rem;
+  box-shadow: rgba(60, 64, 67, 0.3) 0 0.06rem 0.13rem 0,
+    rgba(60, 64, 67, 0.15) 0 0.13rem 0.38rem 0.13rem;
+}
+
+#signout-option {
+  cursor: pointer;
+}
+
+#dropdown.active {
+  display: flex;
+}
+
+.dropdown-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-left: 0;
+  cursor: pointer;
+  color: var(--lightblue-color);
+  font-weight: 700;
+}
+.dropdown-item {
+  padding: 0.65rem 0;
+}
+.dropdown-item:hover {
+  background-color: var(--lightgray-color);
+  transition: background-color 0.31s ease-in-out;
+}
+.dropdown-link {
+  display: block;
+  width: 100%;
+  text-decoration: none;
+  color: var(--lightblue-color);
+}
+
+.user-info {
+  display: none;
+  position: absolute;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: var(--white-color);
+  order: 3;
+  font-size: smaller;
+  font-weight: bold;
+}
+.user-info.active {
+  display: flex;
+  right: 0.5rem;
+}
+
+.user-info img {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 100%;
+}
 
 /* MEDIA QUERY */
 
@@ -403,6 +476,9 @@ footer {
   .nav-links .links a {
     color: var(--blue-color);
   }
+  .user-info {
+    position: inherit;
+  }
 }
 
 @media only screen and (max-width: 600px) {
@@ -411,5 +487,8 @@ footer {
   }
   .action-button {
     text-align: center;
+  }
+  .logo {
+    display: none;
   }
 }

--- a/style.css
+++ b/style.css
@@ -374,14 +374,13 @@ footer {
 #dropdown {
   display: none;
   position: absolute;
-  width: 9.5rem;
+  width: 8rem;
   right: 1.5rem;
-  text-align: center;
-  top: 3rem;
+  top: 2.5rem;
   z-index: 100;
   flex-direction: column;
   justify-content: center;
-  padding: 0.63rem 0;
+  padding: 0.25rem 0;
   background-color: var(--white-color);
   border-radius: 0.63rem;
   font-size: 0.75rem;
@@ -406,7 +405,7 @@ footer {
   font-weight: 700;
 }
 .dropdown-item {
-  padding: 0.65rem 0;
+  padding: 0.75rem 1.75rem;
 }
 .dropdown-item:hover {
   background-color: var(--lightgray-color);
@@ -478,6 +477,9 @@ footer {
   }
   .user-info {
     position: inherit;
+  }
+  .logo {
+    display: none;
   }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -1,15 +1,19 @@
-async function getSelfUser() {
+async function getSelfUser(endpoint = '/users/self') {
   try {
-    const res = await fetch(`${API_BASE_URL}/users/self`, {
+    const res = await fetch(`${API_BASE_URL}${endpoint}`, {
       method: 'GET',
       credentials: 'include',
       headers: {
         'Content-type': 'application/json',
       },
     });
-    const self_user = await res.json();
-    if (res.status === 200) {
-      return self_user;
+    if (endpoint === '/users/self') {
+      const self_user = await res.json();
+      if (res.status === 200) {
+        return self_user;
+      }
+    } else {
+      location.reload();
     }
   } catch (err) {}
 }


### PR DESCRIPTION
**Description:**
In this PR, I've fixed an issue related to the GitHub sign-in process. Previously, even after signing in, the "Sign In" button would still be visible.

To improve the user experience, I've made the following changes:

**User Name and Profile Information:** Now, after successfully signing in with GitHub, users will see their name and profile picture instead of sign in button.

**Dropdown Menu on User Click:** When users click on their name or profile picture, a dropdown menu will appear. This menu provides various options for user interactions and navigation.

**Before**

https://github.com/Real-Dev-Squad/website-dashboard/assets/84411728/34ff26fa-6751-4162-ad22-3b9d5a9140da

**After**

https://github.com/Real-Dev-Squad/website-dashboard/assets/84411728/94e87556-b5a0-4c15-9458-68c6c577292b

**Screenshots of dropdown on different screen**

**Medium Screen**

![screenshots](https://github.com/Real-Dev-Squad/website-dashboard/assets/84411728/9f723c45-3189-4bd3-a24a-86a8171a8c04)

**Small Screen**
![mobilescreen](https://github.com/Real-Dev-Squad/website-dashboard/assets/84411728/90cb5403-2e3f-484e-9fe3-75c81f17ec3e)


**Test Cases**
![testcases](https://github.com/Real-Dev-Squad/website-dashboard/assets/84411728/656329a2-1dc1-42eb-8b52-c6924dad82d6)
