### PR TITLE
Fixed Issue of No Logs Appearing When Clicking on the Parent Div of an Accordion

### DIFF
--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -797,7 +797,7 @@ async function createExtensionCard(data) {
     logContainer.appendChild(logDetailsLines);
 
     // Event listener to append logs once clicked
-    downArrowIcon.addEventListener('click', function () {
+    accordionContainer.addEventListener('click', function () {
       renderLogs({
         extensionRequestId: data.id,
         assigneeName: assigneeNameElement.innerText,


### PR DESCRIPTION
### Developer Name: Joy Gupta

### PR Number(s): 587

### Purpose:
I need to display logs inside the accordion. Now, the accordion can be opened in two ways: either by clicking on the arrow icon or its parent div. When the event listener was attached to the icon, logs weren't displayed when the user clicked on the parent div. This is why I needed to update that element. Now, even if the user clicks on the icon, it will ultimately be listened to by its parent through the concept of event bubbling.

### Issue Ticket Number:
- https://github.com/Real-Dev-Squad/website-dashboard/issues/494

### Backend Changes
- [ ] Yes
- [x] No

### Frontend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [x] Yes
- [ ] No

### Database changes: 
- [ ] Yes
- [x] No

### Breaking changes (If your feature is breaking/missing something please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [x] Yes
- [ ] No

### Proposal Doc
- https://docs.google.com/document/d/1sf-BAs7C6wmfjRVS-82X492hcb_7jAfIM-7pWtizuXE/edit

### QA Instructions, Screenshots, Recordings

Run `yarn test` and there you can see test case running.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/5be3b5a6-cacb-4aea-806e-5ec328d11ef1)
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/cd99e784-e9e2-4a79-8c1b-ca453e910f8a)

### Proof (Before and After)
[simplescreenrecorder-2023-10-26_19.29.19.webm](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/5c6f4017-7737-4f36-933a-f4c9bd17e6b8)

