### PR TITLE
change date styling in standup table header

### DIFF
--- a/standup/script.js
+++ b/standup/script.js
@@ -134,11 +134,23 @@ function createTableHeaderElement() {
         classList: ['dates'],
         scope: 'row',
       });
-      dateCellElement.textContent = `${getDayOfWeek(
-        date,
-      )} ${date.getDate()} ${date.toLocaleString('default', {
-        month: 'long',
-      })} ${date.getFullYear()}`;
+
+      const dayOfWeekElement = document.createElement('div');
+      dayOfWeekElement.textContent = getDayOfWeek(date);
+
+      const dateElement = document.createElement('div');
+      dateElement.textContent =
+        date.getDate() +
+        ' ' +
+        date.toLocaleString('default', { month: 'long' });
+
+      const yearElement = document.createElement('div');
+      yearElement.textContent = date.getFullYear();
+
+      dateCellElement.appendChild(dayOfWeekElement);
+      dateCellElement.appendChild(dateElement);
+      dateCellElement.appendChild(yearElement);
+
       headerRowElement.appendChild(dateCellElement);
     }
   }

--- a/standup/style.css
+++ b/standup/style.css
@@ -132,12 +132,12 @@ body {
 .dates {
   position: sticky;
   top: 0;
-  padding: 1rem;
+  padding: 0.75rem;
   background-color: var(--blue-color);
   color: var(--white-color);
   z-index: 10;
   border: 1px solid var(--black-color);
-  min-width: 6rem;
+  min-width: 7.25rem;
 }
 
 .status {


### PR DESCRIPTION
**Issue** 
https://github.com/Real-Dev-Squad/website-dashboard/issues/591

**Description** : 

Currently the data in the table header is divided into two or three lines, creating a lack of uniformity and potentially impacting the user experience. 

**Proposed Solution**

Ensured a consistent three-line text format for the table header text.

**Before** :

![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/97341921/b4de4f64-64eb-4980-806e-e01b22ca13e6)

**After** : 

![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/97341921/4d0eba31-290e-41aa-b245-1164e643dbd5)

**Note** : As this was primarily a styling correction, there were no alterations made to the Tests.
