### PR TITLE
Bug : Fixed crashing issue

### DIFF
--- a/extension-requests/local-utils.js
+++ b/extension-requests/local-utils.js
@@ -252,6 +252,12 @@ const addSpinner = (container) => {
   return removeSpinner;
 };
 
+/**
+  Generates a formatted date-time string from milliseconds.*
+  @param {number} milliseconds - The number of milliseconds since January 1, 1970 00:00:00 UTC.
+  @returns {string} The formatted date-time string in the format 'YYYY-MM-DDTHH:mm'.
+  
+*/
 function dateTimeString(milliseconds) {
   const date = new Date(milliseconds);
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(

--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -685,11 +685,7 @@ async function createExtensionCard(data) {
     });
     const payloadForLog = {
       body: {},
-      meta: {
-        extensionRequestId: data.id,
-        name: `${currentUserDetails.first_name} ${currentUserDetails?.last_name}`,
-        userId: currentUserDetails.id,
-      },
+      meta: {},
       timestamp: {
         _seconds: Date.now() / 1000,
       },
@@ -699,6 +695,11 @@ async function createExtensionCard(data) {
       const removeSpinner = addSpinner(rootElement);
       rootElement.classList.add('disabled');
       payloadForLog.body.status = Status.APPROVED;
+      payloadForLog.meta = {
+        extensionRequestId: data.id,
+        name: `${currentUserDetails?.first_name} ${currentUserDetails?.last_name}`,
+        userId: currentUserDetails?.id,
+      };
       updateExtensionRequestStatus({
         id: data.id,
         isDev,
@@ -730,6 +731,11 @@ async function createExtensionCard(data) {
       const removeSpinner = addSpinner(rootElement);
       rootElement.classList.add('disabled');
       payloadForLog.body.status = Status.DENIED;
+      payloadForLog.meta = {
+        extensionRequestId: data.id,
+        name: `${currentUserDetails?.first_name} ${currentUserDetails?.last_name}`,
+        userId: currentUserDetails?.id,
+      };
       updateExtensionRequestStatus({
         id: data.id,
         isDev,
@@ -881,8 +887,8 @@ async function createExtensionCard(data) {
       },
       meta: {
         extensionRequestId: data.id,
-        name: `${currentUserDetails.first_name} ${currentUserDetails?.last_name}`,
-        userId: currentUserDetails.id,
+        name: `${currentUserDetails?.first_name} ${currentUserDetails?.last_name}`,
+        userId: currentUserDetails?.id,
       },
       timestamp: {
         _seconds: Date.now() / 1000,
@@ -1061,17 +1067,21 @@ function checkIfPreviouslyRendered(id, logType, log, parentClassName) {
   const alreadyRenderdLogs = renderLogRecord[id] || [];
   let sentence = '';
   let text = '';
+  let name = 'You';
+  if (parentClassName === 'server-log') {
+    name = `${
+      log?.meta?.userId === currentUserDetails?.id
+        ? 'You'
+        : log?.meta?.name || 'Super User'
+    }`;
+  }
   switch (logType) {
     case 'REVIEW': {
       const updationTime = dateDiff(
         Date.now(),
         secondsToMilliSeconds(log?.timestamp?._seconds),
       );
-      text = `${
-        log?.meta?.userId === currentUserDetails.id
-          ? 'You'
-          : log?.meta?.name || 'Super User'
-      } ${log.body.status} this request ${updationTime} ago.`;
+      text = `${name} ${log.body.status} this request ${updationTime} ago.`;
 
       sentence = `
       <div class="log-div ${parentClassName}">
@@ -1085,11 +1095,7 @@ function checkIfPreviouslyRendered(id, logType, log, parentClassName) {
       break;
     }
     case 'ETA': {
-      text = `${
-        log?.meta?.userId === currentUserDetails.id
-          ? 'You'
-          : log?.meta?.name || 'Super User'
-      } changed the ETA from ${fullDateString(
+      text = `${name} changed the ETA from ${fullDateString(
         secondsToMilliSeconds(log.body.oldEndsOn),
       )} to ${fullDateString(secondsToMilliSeconds(log.body.newEndsOn))}.`;
       sentence = `
@@ -1103,13 +1109,7 @@ function checkIfPreviouslyRendered(id, logType, log, parentClassName) {
       break;
     }
     case 'REASON': {
-      text = `${
-        log?.meta?.userId === currentUserDetails.id
-          ? 'You'
-          : log?.meta?.name || 'Super User'
-      } changed the reason from ${log.body.oldReason} to ${
-        log.body.newReason
-      }.`;
+      text = `${name} changed the reason from ${log.body.oldReason} to ${log.body.newReason}.`;
       sentence = `
       <div class="log-div ${parentClassName}"> 
         <img class="log-img" src="/images/edit-icon.png"></img>
@@ -1120,11 +1120,7 @@ function checkIfPreviouslyRendered(id, logType, log, parentClassName) {
     }
 
     case 'TITLE': {
-      text = `${
-        log?.meta?.userId === currentUserDetails.id
-          ? 'You'
-          : log?.meta?.name || 'Super User'
-      } changed the title from ${log.body.oldTitle} to ${log.body.newTitle}.`;
+      text = `${name} changed the title from ${log.body.oldTitle} to ${log.body.newTitle}.`;
       sentence = `
       <div class="log-div ${parentClassName}"> 
         <img class="log-img" src="/images/edit-icon.png"></img>


### PR DESCRIPTION
### Developer Name: Joy Gupta

### PR Number(s): 598

### Purpose:
If the user's self API takes time to resolve, the whole UI was crashing because at some part of the code it was trying to retrieve values from a variable that is still undefined. To solve this, I've added optional chaining and moved data preparation related to the self API inside DOM event listeners to provide it with some extra time.

Before
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/a917ad8e-081b-4c0f-b18f-5cba9d42e2be)


### Issue Ticket Number:
- https://github.com/Real-Dev-Squad/website-dashboard/issues/589

### Backend Changes
- [ ] Yes
- [x] No

### Frontend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [ ] Yes
- [x] No

### Database changes: 
- [ ]  Yes
- [x] No

### Breaking changes (If your feature is breaking/missinsomething please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [x] Yes
- [ ] No

### QA Instructions, Screenshots, Recordings

Run `yarn test` and there you can see test case running.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/f88c3305-58f5-4fdf-afda-7378c35bbccd)


### Working Proof
To mimic the same issue, I've added a setTimeout just for testing purposes.
![image](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/214b1722-8f8d-490a-9121-1885fcad2219)

Now in this case the UI should not crash and should also render logs.

[simplescreenrecorder-2023-10-30_21.23.31.webm](https://github.com/Real-Dev-Squad/website-dashboard/assets/56365512/17cced1c-4ec5-41f8-9693-5c126537f314)


