### PR TITLE
update user count when discord role is removed

### DIFF
--- a/groups/script.js
+++ b/groups/script.js
@@ -281,6 +281,15 @@ async function removeRoleHandler() {
         memberAddRoleBody.roleid,
         memberAddRoleBody.userid,
       );
+      if (isDev) {
+        const groupNameElement = document.getElementById(
+          `name-${memberAddRoleBody.roleid}`,
+        );
+        const currentCount = groupNameElement.getAttribute('data-member-count');
+        if (currentCount !== null && currentCount !== undefined) {
+          groupNameElement.setAttribute('data-member-count', currentCount - 1);
+        }
+      }
       showToaster(res.message);
       UserGroupData = await getUserGroupRoles();
       updateButtonState();


### PR DESCRIPTION
Date: 16/12/2023

Developer Name: @PeeyushPrashant 

### Issue Closes https://github.com/Real-Dev-Squad/website-dashboard/issues/623

### What is the change?

- Update user count in realtime when user unsubscribe any discord role
- Access the HTML element that wraps that particular role (one which user unsubscribe) by using 
   **document.getElementById** method .
- Access the inner attribute (user count) of the element by using **getAttribute** method.
-  Check if the current count is not null and undefined. If true , decrease the count by 1.
-  feature under feature flag



**Documentation Updated?**

-   [ ] Yes
-   [x] No

**Breaking Changes**

-   [ ] Yes
-   [x] No

**Development Tested?**

-   [x] Yes
-   [ ] No

**Tested in Staging?**

-   [ ] Yes
-   [x] No

**Under Feature Flag**

-   [x] Yes
-   [ ] No

**Database Changes**

-   [ ] Yes
-   [x] No

### Before & After Change Screenshots

[screen-capture (4).webm](https://github.com/Real-Dev-Squad/website-dashboard/assets/68290209/72bad207-ebdc-484a-ac35-52969ce422b8)

## Test Coverage
![Screenshot 2023-12-13 211709](https://github.com/Real-Dev-Squad/website-dashboard/assets/68290209/90a5f357-5b6a-4806-a645-23cf771c7079)


## Additional Notes

These tests are failing in dev branch as well, it has not happened because of my changes.
