### PR TITLE
Fix: selected filters badge deletion when x icon is clicked in task-requests page

### DIFF
--- a/__tests__/task-requests/task-request.test.js
+++ b/__tests__/task-requests/task-request.test.js
@@ -517,4 +517,19 @@ describe('badges', () => {
     badges = await page.$$('.badge');
     expect(badges.length).toBe(0);
   });
+
+  it('verifies that badge is removed when delete icon is clicked', async () => {
+    await page.goto(
+      `${SITE_URL}/task-requests/?sort=created-asc&status=denied&dev=true`,
+    );
+
+    let badgeTexts = await getBadgeTexts(page);
+    expect(badgeTexts).toContain('denied');
+
+    const deniedBadgeDeleteIcon = await page.$('.badge__delete');
+    await deniedBadgeDeleteIcon.click();
+
+    badgeTexts = await getBadgeTexts(page);
+    expect(badgeTexts).not.toContain('denied');
+  });
 });

--- a/task-requests/script.js
+++ b/task-requests/script.js
@@ -138,8 +138,11 @@ function handleBadgeDeletion(badgeType, badgeContent) {
 }
 
 function deleteBadge(e, badgeType) {
-  const badgeContent = e.target.textContent;
-  handleBadgeDeletion(badgeType, badgeContent);
+  const badge = e.target.closest('.badge');
+  if (badge) {
+    const badgeContent = badge.querySelector('.badge__name').textContent;
+    handleBadgeDeletion(badgeType, badgeContent);
+  }
 }
 
 function showBadges() {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 15-03-2024
<!--Developer Name Here-->
Developer Name: @VinayakaHegade 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
closes #715 
## Description
- This PR addresses issue #715, where the `deleteBadge` function was not correctly deleting badges when the delete icon was clicked.
- The issue was that the `deleteBadge` function was using `e.target.textContent` to identify the badge to delete. However, when the delete icon (an image element) was clicked, `e.target` was the image element, which doesn't have a `textContent` property.
- So the `deleteBadge` function has been updated to use the `Element.closest()` method to find the closest ancestor with the class 'badge' and get the `textContent` of span inside it.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots

### Before the fix

https://github.com/Real-Dev-Squad/website-dashboard/assets/88454618/e20e6469-04ff-40ae-b6fb-41a1a508ce1d

### After the fix

https://github.com/Real-Dev-Squad/website-dashboard/assets/88454618/e5602356-d093-4840-8e1c-bd7f20bbd0ee


## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![test](https://github.com/Real-Dev-Squad/website-dashboard/assets/88454618/dddcd511-69cb-4124-803d-d09680626ba6)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
