### PR TITLE
Fix: Display 'No extension requests to show!' message after addressing all requests

### DIFF
--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -310,10 +310,10 @@ async function removeCard(element, elementClass) {
     .addEventListener('finish', () => {
       element.style.overflow = '';
       element.remove();
+      if (extensionRequestsContainer.innerHTML === '') {
+        addEmptyPageMessage(extensionRequestsContainer);
+      }
     });
-  if (extensionRequestsContainer.innerHTML === '') {
-    addEmptyPageMessage(extensionRequestsContainer);
-  }
 }
 
 function addCheckbox(labelText, value, groupName) {

--- a/task-requests/details/style.css
+++ b/task-requests/details/style.css
@@ -498,7 +498,6 @@ table tr td {
   padding: 0.5rem;
 
   margin-left: -0.65rem;
-
 }
 
 .requestor_description_details h1 {


### PR DESCRIPTION
…layed after 

<!-- Date Here in dd mmm yyyy-->
Date: 8th April 2024
<!--Developer Name Here-->
Developer Name: @mehra-sourav 

---

## Issue Ticket Number
#738 

## Description
This PR addresses the issue of the extension requests page becoming blank after all extension requests were addressed. 

The cause of this bug was that the logic implemented for showing the message on 0 cards executed immediately without waiting for the dispersal animation of the dismissed card to complete. I've moved that logic to the end of the animation phase, specifically to the event handler of the 'finish' event.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/Real-Dev-Squad/website-dashboard/assets/36883648/984cf0c5-b816-49d0-99a9-9b63b6d7237d



</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
There's some weird network call occurring in the tests that re-fetches the extension request data and interferes with my assertions.

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
