### PR TITLE
Dev to Main Sync

### DIFF
--- a/task-requests/script.js
+++ b/task-requests/script.js
@@ -60,22 +60,25 @@ async function getTaskRequests(query = {}, nextLink) {
 
     if (res.status === 401) {
       showMessage('ERROR', ErrorMessages.UNAUTHENTICATED);
-      return;
+      return { data: [] };
     }
 
     if (res.status === 403) {
       showMessage('ERROR', ErrorMessages.UNAUTHORIZED);
-      return;
+      return { data: [] };
     }
 
     if (res.status === 404) {
       showMessage('ERROR', ErrorMessages.NOT_FOUND);
-      return;
+      return { data: [] };
     }
 
     showMessage('ERROR', ErrorMessages.SERVER_ERROR);
+    return { data: [] };
   } catch (e) {
     console.error(e);
+    showMessage('ERROR', ErrorMessages.SERVER_ERROR);
+    return { data: [] };
   }
 }
 

--- a/task-requests/style.css
+++ b/task-requests/style.css
@@ -362,15 +362,18 @@ body {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
+  justify-items: center;
 }
 .taskRequest__message {
-  line-height: 1.25rem;
+  line-height: 1.2;
   font-weight: 600;
   text-align: center;
   font-size: 1.5rem;
   width: 100%;
   position: absolute;
+  word-wrap: break-word;
 }
+
 .taskRequest__message--error {
   color: var(--color-error);
   font-weight: 600;
@@ -481,6 +484,10 @@ body {
 
   .funnel-icon {
     margin: auto;
+  }
+
+  .taskRequest__message--error {
+    position: static;
   }
 }
 

--- a/task-requests/style.css
+++ b/task-requests/style.css
@@ -364,12 +364,13 @@ body {
   gap: 1rem;
 }
 .taskRequest__message {
-  line-height: 1.25rem;
+  line-height: 1.2;
   font-weight: 600;
   text-align: center;
   font-size: 1.5rem;
   width: 100%;
   position: absolute;
+  word-wrap: break-word;
 }
 .taskRequest__message--error {
   color: var(--color-error);
@@ -481,6 +482,10 @@ body {
 
   .funnel-icon {
     margin: auto;
+  }
+
+  .taskRequest__message--error {
+    position: static;
   }
 }
 

--- a/task-requests/style.css
+++ b/task-requests/style.css
@@ -362,18 +362,15 @@ body {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
-  justify-items: center;
 }
 .taskRequest__message {
-  line-height: 1.2;
+  line-height: 1.25rem;
   font-weight: 600;
   text-align: center;
   font-size: 1.5rem;
   width: 100%;
   position: absolute;
-  word-wrap: break-word;
 }
-
 .taskRequest__message--error {
   color: var(--color-error);
   font-weight: 600;
@@ -484,10 +481,6 @@ body {
 
   .funnel-icon {
     margin: auto;
-  }
-
-  .taskRequest__message--error {
-    position: static;
   }
 }
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: `05 Sep 2024`
<!--Developer Name Here-->
Developer Name: @VaibhavSingh8  

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #810  

## PR's going in this sync
<!--PR's going in this sync-->
- #811 
- #813 
- #814 
- #815 

## Description
- Fixed the wrong error message being displayed for unauthenticated users at the [dashboard site/task-requests](https://dashboard.realdevsquad.com/task-requests) page from "Unexpected error occurred" to correct respective authentication error. 
For eg: In the case of 401 the error displayed should be: "You are unauthenticated to view this section, please login!"

- Fixed the responsiveness of the error message on mobile devices

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
Logged out user:

<img width="1465" alt="Screenshot 2024-09-05 at 6 52 13 PM" src="https://github.com/user-attachments/assets/9700e212-4834-4ea7-a61a-691c14b3dfd0">

<img width="1464" alt="Screenshot 2024-09-05 at 6 51 59 PM" src="https://github.com/user-attachments/assets/2a423d15-a6c1-49f8-9676-b142cbf44cf2">

On Log in:

<img width="1466" alt="Screenshot 2024-09-05 at 6 50 56 PM" src="https://github.com/user-attachments/assets/ef0a7a53-0e89-4327-8a3d-d978dd2fced6">

<img width="1463" alt="Screenshot 2024-09-05 at 6 51 40 PM" src="https://github.com/user-attachments/assets/a49e2f93-e4a8-460c-930c-6abd34268096">


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

<img width="1425" alt="Screenshot 2024-09-05 at 11 42 27 PM" src="https://github.com/user-attachments/assets/fa659ccf-8823-4614-a450-29eebb65d18d">


</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
