### PR TITLE
fix: Displayed error styles breaking on mobile devices

### DIFF
--- a/task-requests/style.css
+++ b/task-requests/style.css
@@ -364,12 +364,13 @@ body {
   gap: 1rem;
 }
 .taskRequest__message {
-  line-height: 1.25rem;
+  line-height: 1.2;
   font-weight: 600;
   text-align: center;
   font-size: 1.5rem;
   width: 100%;
   position: absolute;
+  word-wrap: break-word;
 }
 .taskRequest__message--error {
   color: var(--color-error);
@@ -481,6 +482,10 @@ body {
 
   .funnel-icon {
     margin: auto;
+  }
+
+  .taskRequest__message--error {
+    position: static;
   }
 }
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 05 Sep 2024
<!--Developer Name Here-->
Developer Name: Vaibhav Singh

---

## Issue Ticket Number  
<!--Issue ticket this PR closes-->
- Closes #810 
## Description

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
When Signed in:

<img width="1470" alt="Screenshot 2024-09-05 at 2 43 20 AM" src="https://github.com/user-attachments/assets/3a95057f-a4d3-4bf7-9f3a-e8e4a46b52a5">

<img width="1460" alt="Screenshot 2024-09-05 at 2 44 22 AM" src="https://github.com/user-attachments/assets/35c53f2d-0f14-450c-a717-61d3708cd4df">

After Sign out:

<img width="1466" alt="Screenshot 2024-09-05 at 2 44 54 AM" src="https://github.com/user-attachments/assets/cbae5d75-8802-4fb6-88fd-d1f67ef747c9">

<img width="1451" alt="Screenshot 2024-09-05 at 2 45 18 AM" src="https://github.com/user-attachments/assets/f073b1da-c2f0-4526-bb41-d9e580b80e9e">

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="790" alt="Screenshot 2024-09-05 at 2 48 01 AM" src="https://github.com/user-attachments/assets/ce4d7593-fc00-418c-9bb1-56c30a566106">

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
