### PR TITLE
fix: change the order of extension-requests in the extension request page

### DIFF
--- a/__tests__/extension-requests/extension-requests.test.js
+++ b/__tests__/extension-requests/extension-requests.test.js
@@ -46,9 +46,9 @@ describe('Tests the Extension Requests Screen', () => {
       const url = interceptedRequest.url();
       if (
         url ===
-          'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3APENDING' ||
+          'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3APENDING' ||
         url ===
-          'https://api.realdevsquad.com/extension-requests?dev=true&order=asc'
+          'https://api.realdevsquad.com/extension-requests?dev=true&order=desc'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -96,7 +96,7 @@ describe('Tests the Extension Requests Screen', () => {
             'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
             'Access-Control-Allow-Headers': 'Content-Type, Authorization',
           },
-          body: JSON.stringify(extensionRequestsListPendingDescending),
+          body: JSON.stringify(extensionRequestsListPendingDescending),  //<-------------------
         });
       } else if (
         url === 'https://api.realdevsquad.com/users?search=sunny&size=1'
@@ -196,7 +196,7 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-        'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3APENDING%2Cassignee%3AiODXB6gfsjaZB9p0XlBw'
+        'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3APENDING%2Cassignee%3AiODXB6gfsjaZB9p0XlBw'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -210,7 +210,7 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-        'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3APENDING%2Cassignee%3AiODXB6gfsjaZB9p0XlBw%2B7yzVDl8s1ORNCtH9Ps7K'
+        'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3APENDING%2Cassignee%3AiODXB6gfsjaZB9p0XlBw%2B7yzVDl8s1ORNCtH9Ps7K'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -278,9 +278,9 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-          'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3AAPPROVED%2BPENDING%2BDENIED' ||
+          'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3AAPPROVED%2BPENDING%2BDENIED' ||
         url ===
-          'https://api.realdevsquad.com/extension-requests?dev=true&order=asc&q=status%3AAPPROVED%2BDENIED'
+          'https://api.realdevsquad.com/extension-requests?dev=true&order=desc&q=status%3AAPPROVED%2BDENIED'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -346,7 +346,7 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-        'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3AAPPROVED%2Cassignee%3AiODXB6gfsjaZB9p0XlBw%2B7yzVDl8s1ORNCtH9Ps7K'
+        'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3AAPPROVED%2Cassignee%3AiODXB6gfsjaZB9p0XlBw%2B7yzVDl8s1ORNCtH9Ps7K'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -360,7 +360,7 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-        'https://api.realdevsquad.com/extension-requests?order=asc&size=1&q=status%3APENDING'
+        'https://api.realdevsquad.com/extension-requests?order=desc&size=1&q=status%3APENDING'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -681,7 +681,7 @@ describe('Tests the Extension Requests Screen', () => {
     expect(requestDaysArray).toEqual(sortedRequestDaysArray);
   });
 
-  it('Checks whether the cards displayed in descending order when sort icon is clicked', async () => {
+  it('Checks whether the cards displayed in descending order when sort icon is clicked', async () => {     // <-----------
     const sortButton = await page.$('.sort-button');
 
     await sortButton.click();
@@ -916,12 +916,12 @@ describe('Tests the Extension Requests Screen', () => {
     await page.waitForNetworkIdle();
     const url = page.url();
     expect(url).toBe(
-      `${baseUrl}?order=asc&size=5&q=status%3AAPPROVED%2Cassignee%3Asunny%2Brandhir`,
+      `${baseUrl}?order=desc&size=5&q=status%3AAPPROVED%2Cassignee%3Asunny%2Brandhir`,
     );
   });
   it('Should have UI elements in sync with url', async () => {
     await page.goto(
-      `${baseUrl}/?order=asc&size=5&q=status%3AAPPROVED%2Cassignee%3Asunny%2Brandhir`,
+      `${baseUrl}/?order=desc&size=5&q=status%3AAPPROVED%2Cassignee%3Asunny%2Brandhir`,
     );
     const filterButton = await page.$('#filter-button');
     await filterButton.click();
@@ -936,15 +936,15 @@ describe('Tests the Extension Requests Screen', () => {
     );
     expect(searchText).toBe('sunny,randhir');
     await page.waitForSelector('.sort-button');
-    const ascSortIconDisplayStyle = await page.$eval(
-      '#asc-sort-icon',
+    const descSortIconDisplayStyle = await page.$eval(
+      '#desc-sort-icon',
       (icon) => window.getComputedStyle(icon).display,
     );
-    expect(ascSortIconDisplayStyle).toBe('block');
+    expect(descSortIconDisplayStyle).toBe('block');
   });
 
   it('Should show empty message if all extension requests have been addressed', async () => {
-    await page.goto(`${baseUrl}/?order=asc&size=1&q=status%3APENDING`);
+    await page.goto(`${baseUrl}/?order=desc&size=1&q=status%3APENDING`);
     await page.waitForNetworkIdle();
 
     extensionRequestsElement = await page.$('.extension-requests');

--- a/__tests__/extension-requests/extension-requests.test.js
+++ b/__tests__/extension-requests/extension-requests.test.js
@@ -4,7 +4,7 @@ const {
   extensionRequestsListPending,
   extensionRequestsListApproved,
   extensionRequestResponse,
-  extensionRequestsListPendingDescending,
+  extensionRequestsListPendingAscending,
   extensionRequestsListUserSearch,
   extensionRequestListForAuditLogs,
 } = require('../../mock-data/extension-requests');
@@ -86,7 +86,7 @@ describe('Tests the Extension Requests Screen', () => {
         });
       } else if (
         url ===
-        'https://api.realdevsquad.com/extension-requests?order=desc&size=5&q=status%3APENDING'
+        'https://api.realdevsquad.com/extension-requests?order=asc&size=5&q=status%3APENDING'
       ) {
         interceptedRequest.respond({
           status: 200,
@@ -96,7 +96,7 @@ describe('Tests the Extension Requests Screen', () => {
             'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
             'Access-Control-Allow-Headers': 'Content-Type, Authorization',
           },
-          body: JSON.stringify(extensionRequestsListPendingDescending),  //<-------------------
+          body: JSON.stringify(extensionRequestsListPendingAscending),
         });
       } else if (
         url === 'https://api.realdevsquad.com/users?search=sunny&size=1'
@@ -677,11 +677,11 @@ describe('Tests the Extension Requests Screen', () => {
 
     const sortedRequestDaysArray = requestDaysArray
       .slice()
-      .sort((a, b) => a - b);
+      .sort((a, b) => b - a);
     expect(requestDaysArray).toEqual(sortedRequestDaysArray);
   });
 
-  it('Checks whether the cards displayed in descending order when sort icon is clicked', async () => {     // <-----------
+  it('Checks whether the cards displayed in ascending order when sort icon is clicked', async () => {
     const sortButton = await page.$('.sort-button');
 
     await sortButton.click();
@@ -697,7 +697,7 @@ describe('Tests the Extension Requests Screen', () => {
       requestDaysArray.push(requestedDays.slice(5));
     }
 
-    const sortedRequestDaysArray = [...requestDaysArray].sort().reverse();
+    const sortedRequestDaysArray = [...requestDaysArray].sort();
 
     expect(requestDaysArray).toEqual(sortedRequestDaysArray);
   });

--- a/__tests__/user-details/task-duedate-hover.test.js
+++ b/__tests__/user-details/task-duedate-hover.test.js
@@ -182,7 +182,7 @@ describe('Tasks On User Management Page', () => {
 
   it('Scroll of task should work', async () => {
     await page.goto(
-      'http://localhost:8000/users/details/index.html?username=ajeyakrishna',
+      'http://localhost:8000/users/details/index.html?username=ankush',
     );
     await page.waitForNetworkIdle();
     const taskDiv = await page.$$('.accordion-tasks');
@@ -213,12 +213,12 @@ describe('Tasks On User Management Page', () => {
     await page.waitForNetworkIdle();
 
     let renderedTasks = await userTasksDevDiv.$$('.user-task');
-    expect(Array.from(renderedTasks).length).toBe(12);
+    expect(Array.from(renderedTasks).length).toBe(15);
   });
 
   it('New task card should have all the detail fields', async () => {
     await page.goto(
-      'http://localhost:8000/users/details/index.html?username=ajeyakrishna',
+      'http://localhost:8000/users/details/index.html?username=ankush',
     );
     await page.waitForNetworkIdle();
     const taskDiv = await page.$$('.accordion-tasks');
@@ -236,7 +236,7 @@ describe('Tasks On User Management Page', () => {
     );
 
     expect(firstTaskHTML).toContain('<div class="task-title">');
-    expect(firstTaskHTML).not.toContain('<progress');
+    expect(firstTaskHTML).toContain('<progress');
     expect(firstTaskHTML).toContain('<div class="detail-block eta">');
     expect(firstTaskHTML).toContain('<div class="detail-block status">');
     expect(firstTaskHTML).toContain('<div class="detail-block startedOn">');
@@ -251,7 +251,7 @@ describe('Tasks On User Management Page', () => {
     );
 
     expect(secondTaskHTML).toContain('<div class="task-title">');
-    expect(secondTaskHTML).not.toContain('<progress');
+    expect(secondTaskHTML).toContain('<progress');
     expect(secondTaskHTML).toContain('<div class="detail-block eta">');
     expect(secondTaskHTML).toContain('<div class="detail-block status">');
     expect(secondTaskHTML).toContain('<div class="detail-block startedOn">');
@@ -266,7 +266,7 @@ describe('Tasks On User Management Page', () => {
     );
 
     expect(thirdTaskHTML).toContain('<div class="task-title">');
-    expect(thirdTaskHTML).not.toContain('<progress');
+    expect(thirdTaskHTML).toContain('<progress');
     expect(thirdTaskHTML).toContain('<div class="detail-block eta">');
     expect(thirdTaskHTML).toContain('<div class="detail-block status">');
     expect(thirdTaskHTML).toContain('<div class="detail-block startedOn">');

--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -133,11 +133,11 @@ const render = async () => {
     const assigneeFilterState = userIdList.length ? userIdList : '';
     filterStates.assignee = assigneeFilterState;
     if (!filterStates.order) {
-      filterStates.order = Order.ASCENDING;
+      filterStates.order = Order.DESCENDING;
     }
   } else {
     filterStates.status = Status.PENDING;
-    filterStates.order = Order.ASCENDING;
+    filterStates.order = Order.DESCENDING;
     filterStates.size = DEFAULT_PAGE_SIZE;
   }
   updateUIBasedOnFilterStates();

--- a/mock-data/extension-requests/index.js
+++ b/mock-data/extension-requests/index.js
@@ -24,7 +24,7 @@ const extensionRequestsList = {
       title: 'A new title',
     },
   ],
-  next: '/extension-requests&size=5&order=asc',
+  next: '/extension-requests&size=5&order=desc',
 };
 
 const extensionRequestsListPendingDescending = {
@@ -143,7 +143,7 @@ const extensionRequestsListPending = {
       title: 'A different title 2',
     },
   ],
-  next: '/extension-requests?order=asc&size=5&q=status%3APENDING',
+  next: '/extension-requests?order=desc&size=5&q=status%3APENDING',
 };
 
 const extensionRequestsListApproved = {
@@ -172,7 +172,7 @@ const extensionRequestsListApproved = {
       title: 'test title',
     },
   ],
-  next: '/extension-requests?q=status%3AAPPROVED&size=5&order=asc',
+  next: '/extension-requests?q=status%3AAPPROVED&size=5&order=desc',
 };
 
 const extensionRequestResponse = {

--- a/mock-data/extension-requests/index.js
+++ b/mock-data/extension-requests/index.js
@@ -27,18 +27,29 @@ const extensionRequestsList = {
   next: '/extension-requests&size=5&order=desc',
 };
 
-const extensionRequestsListPendingDescending = {
+const extensionRequestsListPendingAscending = {
   message: 'Extension Requests returned successfully!',
   allExtensionRequests: [
     {
+      assignee: 'sunny',
+      id: 'lGQ3AjUlgNB6Jd8jXaEC',
+      newEndsOn: 1690528980,
+      oldEndsOn: 1689954609.948,
+      reason: 'test reason',
+      status: 'PENDING',
+      taskId: 'PYj79ki2agB0q5JN3kUf',
+      timestamp: 1691734400.045, // Oldest timestamp
+      title: 'A title',
+    },
+    {
       assignee: 'randhir',
-      id: 'QISvF7kAmnD9vXHwwIs8',
+      id: 'QISvF7kAmnD9vXHwwIsG',
       newEndsOn: 1690528980,
       oldEndsOn: 1689954609.948,
       reason: 'b',
       status: 'PENDING',
       taskId: 'PYj79ki2agB0q5JN3kUf',
-      timestamp: 1691993520.03,
+      timestamp: 1691820785.341,
       title: 'A new title',
     },
     {
@@ -54,25 +65,14 @@ const extensionRequestsListPendingDescending = {
     },
     {
       assignee: 'randhir',
-      id: 'QISvF7kAmnD9vXHwwIsG',
+      id: 'QISvF7kAmnD9vXHwwIs8',
       newEndsOn: 1690528980,
       oldEndsOn: 1689954609.948,
       reason: 'b',
       status: 'PENDING',
       taskId: 'PYj79ki2agB0q5JN3kUf',
-      timestamp: 1691820785.341,
+      timestamp: 1691993520.03, // Most recent timestamp
       title: 'A new title',
-    },
-    {
-      assignee: 'sunny',
-      id: 'lGQ3AjUlgNB6Jd8jXaEC',
-      newEndsOn: 1690528980,
-      oldEndsOn: 1689954609.948,
-      reason: 'test reason',
-      status: 'PENDING',
-      taskId: 'PYj79ki2agB0q5JN3kUf',
-      timestamp: 1691734400.045,
-      title: 'A title',
     },
   ],
   next: '/extension-requests?order=desc&size=5&q=status%3APENDING',
@@ -223,7 +223,7 @@ module.exports = {
   extensionRequestsListApproved,
   extensionRequestsListPending,
   extensionRequestResponse,
-  extensionRequestsListPendingDescending,
+  extensionRequestsListPendingAscending,
   extensionRequestsListUserSearch,
   extensionRequestListForAuditLogs,
 };


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 11 Sep 2024
<!--Developer Name Here-->
Developer Name: Suvidh Kaushik

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #816 
## Description
The default order in the extension-requests page is set to oldest first. However, the expected order is newest first(descending)
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot 2024-09-11 002026](https://github.com/user-attachments/assets/0b957d52-3e2e-4588-ae18-1b5e4515f281)
![Screenshot 2024-09-11 002042](https://github.com/user-attachments/assets/ec040f1d-3302-4b8c-b237-3cf9e2daa5ec)

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot 2024-09-11 002528](https://github.com/user-attachments/assets/ce21daf7-ff3a-411d-aa60-4a19356c8adb)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
