### PR TITLE
fix: discord group search for multiple words in same string

### DIFF
--- a/__tests__/groups/group.test.js
+++ b/__tests__/groups/group.test.js
@@ -245,7 +245,7 @@ describe('Discord Groups Page', () => {
   });
 
   test('Should display only specified groups when name=<group-name> with different case', async () => {
-    const groupNames = 'fIrSt,DSA+COdInG';
+    const groupNames = 'fIrSt,COdInG';
     await page.goto(`${PAGE_URL}/groups?name=${groupNames}`);
     await page.waitForNetworkIdle();
 

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -128,15 +128,21 @@ function removeGroupKeywordFromDiscordRoleName(groupName) {
 
 function getDiscordGroupIdsFromSearch(groups, multipleGroupSearch) {
   if (!multipleGroupSearch) return groups.map((group) => group.id);
+
   const GROUP_SEARCH_SEPARATOR = ',';
   const searchGroups = multipleGroupSearch
     .split(GROUP_SEARCH_SEPARATOR)
     .map((group) => group.trim().toLowerCase());
+
   const matchGroups = groups.filter((group) =>
     searchGroups.some((searchGroup) =>
-      group.title.toLowerCase().startsWith(searchGroup),
+      group.title
+        .toLowerCase()
+        .split(' ')
+        .some((word) => word.startsWith(searchGroup)),
     ),
   );
+
   return matchGroups.map((group) => group.id);
 }
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 20-10-2024
<!--Developer Name Here-->
Developer Name: Surendar Singh

---

## Description
<!--Description of the changes made in this PR-->
- Modified the discord group search to support the prefix of multiple words in the same discord name.
- Before It was only searching for the prefix of the whole string, Now it will support searching for prefixes of all the words in the same name.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Before fix</summary>
<!-- Attach your screenshots here👇-->

![image](https://github.com/user-attachments/assets/df95b405-4aec-4ea6-92b5-b4fbbe972463)

![image](https://github.com/user-attachments/assets/68f5dd4c-a6fa-4901-8139-5eb6d3343f37)

</details>

<details>
<summary>After fix</summary>
<!-- Attach your screenshots here👇-->

![image](https://github.com/user-attachments/assets/dbcf1e2a-bfaf-4db4-b52a-0a4a0c455181)

![image](https://github.com/user-attachments/assets/3323fe7c-98b7-49dd-89a4-7a9d0eaaf964)

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot</summary>
<!-- Attach your screenshots here👇-->

![image](https://github.com/user-attachments/assets/b45d2e1b-9215-42fc-ad92-8131f29a8b65)


</details>

<!--Attach Details on test coverage and outcomes-->
