### PR TITLE
Fix: Incorrect Error Message and UI issues for Non-Super Users on Request Actions  

### DIFF
--- a/requests/constants.js
+++ b/requests/constants.js
@@ -27,6 +27,7 @@ const ErrorMessages = {
   OOO_NOT_FOUND: 'OOO Requests not found',
   EXTENSION_NOT_FOUND: 'Extension Requests not found',
   ONBOARDING_EXTENSION_NOT_FOUND: 'Onboarding extension Requests not found',
+  UNAUTHORIZED_ACTION: 'You are unauthorized to perform this action',
   SERVER_ERROR: 'Unexpected error occurred',
 };
 

--- a/requests/script.js
+++ b/requests/script.js
@@ -511,8 +511,8 @@ async function acceptRejectRequest(id, reqBody) {
     } else {
       switch (res.status) {
         case 401:
-          showToast(ErrorMessages.UNAUTHENTICATED, 'failure');
-          showMessage('ERROR', ErrorMessages.UNAUTHENTICATED);
+          showToast(ErrorMessages.UNAUTHORIZED_ACTION, 'failure');
+          showMessage('ERROR', ErrorMessages.UNAUTHORIZED_ACTION);
           break;
         case 403:
           showToast(ErrorMessages.UNAUTHENTICATED, 'failure');
@@ -585,6 +585,9 @@ async function performAcceptRejectAction(isAccepted, e) {
       showMessage('ERROR', ErrorMessages.SERVER_ERROR);
     }
   }
+
+  nextLink = '';
+  await renderRequestCards({ state: statusValue, sort: sortByValue });
 }
 
 function showToast(message, type) {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 14 Mar 2025
<!--Developer Name Here-->
Developer Name: @Mridxl

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #959 

## Description
<!--Description of the changes made in this PR-->
This PR fixes the incorrect error message shown when a non-super user clicks the "Accept" or "Reject" button on requests. Additionally, it ensures that request cards remain visible on the page instead of disappearing when an error occurs. The error message will now be displayed only via a toast notification without altering the state of the request list.


### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/990d3904-b694-4068-bb5d-9290bf1c3c1b)


</details>

<details>
<summary>Screen Recording</summary>

https://github.com/user-attachments/assets/cd806716-be43-4e4e-a9c4-66fb9c67d12f


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/d0ba84a1-d598-440c-bc0d-b70dd9012b63)

</details>

<!--Attach Details on test coverage and outcomes-->