### PR TITLE
Dev to Main Sync

### DIFF
--- a/__tests__/requests/requests.test.js
+++ b/__tests__/requests/requests.test.js
@@ -129,6 +129,18 @@ describe('Tests the request cards', () => {
     await browser.close();
   });
 
+  it('should not show the error toast ui after reloading a page', async () => {
+    await page.click('#extension_tab_link');
+    expect(page.url()).toContain('type=extension');
+    await page.reload();
+    expect(page.url()).toContain('type=extension');
+    const isErrorToastHidden = await page.$eval(
+      '[data-testid="toast"]',
+      (e) => e.classList.contains('hidden') && e.classList.length == 1,
+    );
+    expect(isErrorToastHidden).toBe(true);
+  });
+
   it('should match the request page url with correct request tab link after reloading the page', async () => {
     await page.click('#extension_tab_link');
     expect(page.url()).toContain('type=extension');
@@ -155,7 +167,11 @@ describe('Tests the request cards', () => {
   });
 
   it('should update the card when the accept or reject button is clicked for OOO requests', async () => {
+    await page.goto(`${LOCAL_TEST_PAGE_URL}/requests`);
+    await page.waitForNetworkIdle();
+
     await page.click('#ooo_tab_link');
+    expect(page.url()).toContain('type=ooo');
 
     await page.waitForSelector('.request__status');
     const statusButtonText = await page.$eval(
@@ -206,6 +222,37 @@ describe('Tests the request cards', () => {
     await page.waitForNetworkIdle();
     const filterContainer = await page.$('[data-testid="filter-container"]');
     expect(await filterContainer.isVisible()).toBe(false);
+  });
+
+  it('should show requests cards after reloading the page', async () => {
+    await page.goto(`${LOCAL_TEST_PAGE_URL}/requests`);
+    await page.waitForNetworkIdle();
+
+    await page.click('#extension_tab_link');
+    expect(page.url()).toContain('type=extension');
+
+    await page.reload();
+    expect(page.url()).toContain('type=extension');
+
+    await page.waitForSelector('[data-testid="extension-request-card"]', {
+      state: 'visible',
+    });
+    const extensionCards = await page.$$(
+      '[data-testid="extension-request-card"]',
+    );
+    expect(extensionCards.length).toBe(1);
+
+    await page.click('#ooo_tab_link');
+    expect(page.url()).toContain('type=ooo');
+
+    await page.reload();
+    expect(page.url()).toContain('type=ooo');
+
+    await page.waitForSelector('[data-testid="ooo-request-card"]', {
+      state: 'visible',
+    });
+    const oooCards = await page.$$('[data-testid="ooo-request-card"]');
+    expect(oooCards.length).toBe(1);
   });
 
   describe('Onboarding Requests UI (Dev Mode Enabled)', () => {

--- a/requests/index.html
+++ b/requests/index.html
@@ -57,7 +57,7 @@
             >Extension</a
           >
         </nav>
-        <div id="toast" class="hidden">
+        <div id="toast" class="hidden" data-testid="toast">
           <div class="message"></div>
           <div class="progress-bar"></div>
         </div>

--- a/requests/script.js
+++ b/requests/script.js
@@ -19,7 +19,7 @@ const filterOptionsContainer = document.getElementById(
 );
 const applyFilterButton = document.getElementById('applyFilterButton');
 const userNameFilterInput = document.getElementById('assignee-search-input');
-let currentReqType = params.get('type') ?? OOO_REQUEST_TYPE;
+let currentReqType = params.get('type')?.toUpperCase() ?? OOO_REQUEST_TYPE;
 let selected__tab__class = 'selected__tab';
 let statusValue = null;
 let sortByValue = null;
@@ -63,6 +63,7 @@ const intersectionObserver = new IntersectionObserver(async (entries) => {
       state: statusValue,
       sort: sortByValue,
       next: nextLink,
+      requestType: currentReqType,
     });
   }
 });
@@ -81,10 +82,14 @@ oooTabLink.addEventListener('click', async function (event) {
   nextLink = '';
   deselectRadioButtons();
   userNameFilterInput.value = '';
-  updateTabLink(currentReqType.toUpperCase());
+  updateTabLink(currentReqType);
   changeFilter();
   updateUrlWithQuery(currentReqType);
-  await renderRequestCards({ state: statusValue, sort: sortByValue });
+  await renderRequestCards({
+    state: statusValue,
+    sort: sortByValue,
+    requestType: currentReqType,
+  });
 });
 
 extensionTabLink.addEventListener('click', async function (event) {
@@ -94,10 +99,14 @@ extensionTabLink.addEventListener('click', async function (event) {
   nextLink = '';
   deselectRadioButtons();
   userNameFilterInput.value = '';
-  updateTabLink(currentReqType.toUpperCase());
+  updateTabLink(currentReqType);
   changeFilter();
   updateUrlWithQuery(currentReqType);
-  await renderRequestCards({ state: statusValue, sort: sortByValue });
+  await renderRequestCards({
+    state: statusValue,
+    sort: sortByValue,
+    requestType: currentReqType,
+  });
 });
 
 onboardingExtensionTabLink.addEventListener('click', async function (event) {
@@ -107,10 +116,14 @@ onboardingExtensionTabLink.addEventListener('click', async function (event) {
   nextLink = '';
   deselectRadioButtons();
   userNameFilterInput.value = '';
-  updateTabLink(currentReqType.toUpperCase());
+  updateTabLink(currentReqType);
   changeFilter();
   updateUrlWithQuery(currentReqType);
-  await renderRequestCards({ state: statusValue, sort: sortByValue });
+  await renderRequestCards({
+    state: statusValue,
+    sort: sortByValue,
+    requestType: currentReqType,
+  });
 });
 
 function updateUrlWithQuery(type) {
@@ -470,7 +483,7 @@ async function renderRequestCards(queries = {}) {
     if (userDetails.length === 0) {
       userDetails = await getInDiscordUserList();
     }
-    requestResponse = await getRequests(currentReqType, queries);
+    requestResponse = await getRequests(queries?.requestType, queries);
 
     for (const request of requestResponse?.data || []) {
       let superUserDetails;
@@ -597,7 +610,11 @@ async function performAcceptRejectAction(isAccepted, e) {
   }
 
   nextLink = '';
-  await renderRequestCards({ state: statusValue, sort: sortByValue });
+  await renderRequestCards({
+    state: statusValue,
+    sort: sortByValue,
+    requestType: currentReqType,
+  });
 }
 
 function showToast(message, type) {
@@ -660,6 +677,7 @@ applyFilterButton.addEventListener('click', async (event) => {
   const requestData = {
     state: getCheckedValues() || statusValue,
     sort: sortByValue,
+    requestType: currentReqType,
   };
 
   const username = userNameFilterInput.value.trim();
@@ -698,7 +716,10 @@ userNameFilterInput.addEventListener(
             suggestionContainer.classList.add('hidden');
             requestContainer.innerHTML = '';
 
-            const requestData = { requestedBy: user.username };
+            const requestData = {
+              requestedBy: user?.username,
+              requestType: currentReqType,
+            };
             await renderRequestCards(requestData);
           });
 
@@ -724,6 +745,7 @@ userNameFilterInput.addEventListener('keydown', async function (evt) {
     const requestData = {
       state: statusValue,
       sort: sortByValue,
+      requestType: currentReqType,
     };
 
     if (values.length > 0) {
@@ -768,7 +790,11 @@ function populateStatus() {
     filterModal.classList.add('hidden');
     deselectRadioButtons();
     requestContainer.innerHTML = '';
-    await renderRequestCards({ state: statusValue, sort: sortByValue });
+    await renderRequestCards({
+      state: statusValue,
+      sort: sortByValue,
+      requestType: currentReqType,
+    });
   });
 
   filterTitle.appendChild(clearButton);
@@ -778,6 +804,10 @@ function populateStatus() {
     addRadioButton(name, id, 'status-filter');
   }
 }
-updateTabLink(currentReqType.toUpperCase());
+updateTabLink(currentReqType);
 populateStatus();
-renderRequestCards({ state: statusValue, sort: sortByValue });
+renderRequestCards({
+  state: statusValue,
+  sort: sortByValue,
+  requestType: currentReqType,
+});


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 16 April, 2025
<!--Developer Name Here-->
Developer Name: @pankajjs 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #972 

## PR's going in Sync
- #973 
## Description
@pankajjs's PR fixes an issue where error UI toast were being shown in /requests page after refreshing the page. Now, it correctly shows the requests card and hides the error UI toast.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshots</summary>
Working video of PR #973 

[screen-capture (1).webm](https://github.com/user-attachments/assets/02a71ca4-33ca-42d8-a489-827511cdb3d3)


<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
