### PR TITLE
Add Tests for Reusable Filter Component

### DIFF
--- a/__tests__/applications/applications.test.js
+++ b/__tests__/applications/applications.test.js
@@ -361,4 +361,20 @@ describe('Applications page', () => {
       'application updated successfully!',
     );
   });
+
+  it('should display only accepted applications after applying the "ACCEPTED" filter when dev=true', async () => {
+    await page.goto(`${LOCAL_TEST_PAGE_URL}/applications?dev=true`);
+    await page.waitForNetworkIdle();
+    await page.click('[data-testid="filter-component-toggle-button"]');
+    const applyFilterButton = '[data-testid="apply-filter-component-button"]';
+    await page.waitForSelector(applyFilterButton, { visible: true });
+
+    await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
+
+    await page.click(applyFilterButton);
+
+    await page.waitForNetworkIdle();
+    const applicationCardElements = await page.$$('.application-card');
+    expect(applicationCardElements.length).toBe(acceptedApplications.length);
+  });
 });

--- a/__tests__/applications/applications.test.js
+++ b/__tests__/applications/applications.test.js
@@ -130,9 +130,6 @@ describe('Applications page', () => {
 
   afterEach(async () => {
     await page.close();
-  });
-
-  afterAll(async () => {
     await browser.close();
   });
 
@@ -368,11 +365,8 @@ describe('Applications page', () => {
     await page.click('[data-testid="filter-component-toggle-button"]');
     const applyFilterButton = '[data-testid="apply-filter-component-button"]';
     await page.waitForSelector(applyFilterButton, { visible: true });
-
     await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
-
     await page.click(applyFilterButton);
-
     await page.waitForNetworkIdle();
     const applicationCardElements = await page.$$('.application-card');
     expect(applicationCardElements.length).toBe(acceptedApplications.length);

--- a/__tests__/components/filter.test.js
+++ b/__tests__/components/filter.test.js
@@ -1,0 +1,266 @@
+const puppeteer = require('puppeteer');
+
+const {
+  fetchedApplications,
+  acceptedApplications,
+} = require('../../mock-data/applications');
+const { superUserForAudiLogs } = require('../../mock-data/users');
+const {
+  STAGING_API_URL,
+  LOCAL_TEST_PAGE_URL,
+} = require('../../mock-data/constants');
+
+describe('Filter Component Core Functionality', () => {
+  let browser;
+  let page;
+
+  jest.setTimeout(60000);
+
+  const filterButtonSelector = '[data-testid="filter-component-toggle-button"]';
+  const filterModalSelector = '[data-testid="filter-component-modal"]';
+  const applyFilterButtonSelector =
+    '[data-testid="apply-filter-component-button"]';
+  const clearFilterButtonSelector =
+    '[data-testid="filter-component-clear-button"]';
+  const activeFilterTagsSelector = '[data-testid="active-filter-tags"]';
+
+  beforeEach(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      ignoreHTTPSErrors: true,
+      args: ['--incognito', '--disable-web-security'],
+    });
+    page = await browser.newPage();
+    await page.setRequestInterception(true);
+
+    page.on('request', (interceptedRequest) => {
+      const url = interceptedRequest.url();
+      if (url === `${STAGING_API_URL}/applications?dev=true`) {
+        interceptedRequest.respond({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            applications: acceptedApplications,
+            totalCount: acceptedApplications.length,
+          }),
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          },
+        });
+      } else {
+        interceptedRequest.continue();
+      }
+    });
+
+    await page.goto(`${LOCAL_TEST_PAGE_URL}/applications?dev=true`);
+    await page.waitForSelector(filterButtonSelector);
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('should render filter toggle button and hide filter modal when page load', async () => {
+    const filterButton = await page.$(filterButtonSelector);
+    expect(filterButton).toBeTruthy();
+    const filterModal = await page.$(filterModalSelector);
+    expect(filterModal).toBeTruthy();
+    const isModalHidden = await page.$eval(filterModalSelector, (el) =>
+      el.classList.contains('hidden'),
+    );
+    expect(isModalHidden).toBe(true);
+  });
+
+  it('should open filter modal with options on when click on filter toggle button', async () => {
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+
+    const isModalHidden = await page.$eval(filterModalSelector, (el) =>
+      el.classList.contains('hidden'),
+    );
+    expect(isModalHidden).toBe(false);
+    const applyButton = await page.$(applyFilterButtonSelector);
+    expect(applyButton).toBeTruthy();
+    const clearButton = await page.$(clearFilterButtonSelector);
+    expect(clearButton).toBeTruthy();
+    const checkbox = await page.$(`input[type="checkbox"][id="ACCEPTED"]`);
+    expect(checkbox).toBeTruthy();
+  });
+
+  it('should toggle the clear button state based on checkbox selection', async () => {
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+
+    let isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(true);
+
+    await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
+    isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(false);
+
+    await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
+    isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(true);
+  });
+
+  it('should apply filter, update URL, and display the corresponding filter tag', async () => {
+    const statusToApply = 'ACCEPTED';
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+
+    await page.click(`input[type="checkbox"][id="${statusToApply}"]`);
+
+    await page.click(applyFilterButtonSelector);
+    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForNetworkIdle();
+
+    expect(page.url()).toContain(`status=${statusToApply.toLowerCase()}`);
+
+    const filterTagSelector = `${activeFilterTagsSelector} .filter__component__tag[data-status="${statusToApply}"]`;
+    const displayedTag = await page.$(filterTagSelector);
+    expect(displayedTag).toBeTruthy();
+
+    const isModalHidden = await page.$eval(filterModalSelector, (el) =>
+      el.classList.contains('hidden'),
+    );
+    expect(isModalHidden).toBe(true);
+  });
+
+  it('should clear filter via Clear button', async () => {
+    const statusToApply = 'PENDING';
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    await page.click(`input[type="checkbox"][id="${statusToApply}"]`);
+    await page.click(applyFilterButtonSelector);
+    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForNetworkIdle();
+    expect(page.url()).toContain(`status=${statusToApply.toLowerCase()}`);
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    await page.click(clearFilterButtonSelector);
+    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForNetworkIdle();
+
+    expect(page.url()).not.toContain('status=');
+    const tag = await page.$(
+      `${activeFilterTagsSelector} .filter__component__tag[data-status="${statusToApply}"]`,
+    );
+    expect(tag).toBeFalsy();
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    const isCheckboxChecked = await page.$eval(
+      `input[type="checkbox"][id="${statusToApply}"]`,
+      (el) => el.checked,
+    );
+    expect(isCheckboxChecked).toBe(false);
+    const isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(true);
+  });
+
+  it('should clear filter via tag close icon', async () => {
+    const statusToApply = 'ACCEPTED';
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    await page.click(`input[type="checkbox"][id="${statusToApply}"]`);
+    await page.click(applyFilterButtonSelector);
+    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForNetworkIdle();
+    expect(page.url()).toContain(`status=${statusToApply.toLowerCase()}`);
+    const tagSelector = `${activeFilterTagsSelector} .filter__component__tag[data-status="${statusToApply}"]`;
+    let tag = await page.$(tagSelector);
+    expect(tag).toBeTruthy();
+
+    await page.click(`${tagSelector} .filter__component__tag__close`);
+    await page.waitForNetworkIdle();
+
+    expect(page.url()).not.toContain('status=');
+    tag = await page.$(tagSelector);
+    expect(tag).toBeFalsy();
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    const isCheckboxChecked = await page.$eval(
+      `input[type="checkbox"][id="${statusToApply}"]`,
+      (el) => el.checked,
+    );
+    expect(isCheckboxChecked).toBe(false);
+    const isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(true);
+  });
+
+  it('should sync checkbox state and tag with URL status param on load', async () => {
+    await page.goto(
+      `${LOCAL_TEST_PAGE_URL}/applications?status=accepted&dev=true`,
+    );
+    await page.waitForNetworkIdle();
+
+    const status = 'ACCEPTED';
+    const tag = await page.$(
+      `${activeFilterTagsSelector} .filter__component__tag[data-status="${status}"]`,
+    );
+    expect(tag).toBeTruthy();
+
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+    const isCheckboxChecked = await page.$eval(
+      `input[type="checkbox"][id="${status}"]`,
+      (el) => el.checked,
+    );
+    expect(isCheckboxChecked).toBe(true);
+    const isClearButtonDisabled = await page.$eval(
+      clearFilterButtonSelector,
+      (el) => el.disabled,
+    );
+    expect(isClearButtonDisabled).toBe(false);
+  });
+
+  it('should allow only single selection on application page', async () => {
+    await page.click(filterButtonSelector);
+    await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
+
+    await page.click(`input[type="checkbox"][id="PENDING"]`);
+    let isPendingChecked = await page.$eval(
+      `input[type="checkbox"][id="PENDING"]`,
+      (el) => el.checked,
+    );
+    expect(isPendingChecked).toBe(true);
+
+    await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
+    isPendingChecked = await page.$eval(
+      `input[type="checkbox"][id="PENDING"]`,
+      (el) => el.checked,
+    );
+    let isAcceptedChecked = await page.$eval(
+      `input[type="checkbox"][id="ACCEPTED"]`,
+      (el) => el.checked,
+    );
+
+    expect(isPendingChecked).toBe(false);
+    expect(isAcceptedChecked).toBe(true);
+  });
+});

--- a/__tests__/components/filter.test.js
+++ b/__tests__/components/filter.test.js
@@ -174,11 +174,11 @@ describe('Filter Component Core Functionality', () => {
 
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
-    const isCheckboxChecked = await page.$eval(
+    const isPendingChecked = await page.$eval(
       `input[type="checkbox"][id="${statusToApply}"]`,
       (el) => el.checked,
     );
-    expect(isCheckboxChecked).toBe(false);
+    expect(isPendingChecked).toBe(false);
     const isClearButtonDisabled = await page.$eval(
       clearFilterButtonSelector,
       (el) => el.disabled,
@@ -209,11 +209,11 @@ describe('Filter Component Core Functionality', () => {
 
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
-    const isCheckboxChecked = await page.$eval(
+    const isAcceptedChecked = await page.$eval(
       `input[type="checkbox"][id="${statusToApply}"]`,
       (el) => el.checked,
     );
-    expect(isCheckboxChecked).toBe(false);
+    expect(isAcceptedChecked).toBe(false);
     const isClearButtonDisabled = await page.$eval(
       clearFilterButtonSelector,
       (el) => el.disabled,
@@ -235,16 +235,16 @@ describe('Filter Component Core Functionality', () => {
 
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
-    const isCheckboxChecked = await page.$eval(
+    const isAcceptedChecked = await page.$eval(
       `input[type="checkbox"][id="${acceptedStatus}"]`,
       (el) => el.checked,
     );
-    expect(isCheckboxChecked).toBe(true);
-    const isClearButtonEnable = await page.$eval(
+    expect(isAcceptedChecked).toBe(true);
+    const isClearButtonEnabled = await page.$eval(
       clearFilterButtonSelector,
       (el) => !el.disabled,
     );
-    expect(isClearButtonEnable).toBe(true);
+    expect(isClearButtonEnabled).toBe(true);
   });
 
   it('should apply only one filter on application page', async () => {

--- a/__tests__/components/filter.test.js
+++ b/__tests__/components/filter.test.js
@@ -1,10 +1,6 @@
 const puppeteer = require('puppeteer');
 
-const {
-  fetchedApplications,
-  acceptedApplications,
-} = require('../../mock-data/applications');
-const { superUserForAudiLogs } = require('../../mock-data/users');
+const { acceptedApplications } = require('../../mock-data/applications');
 const {
   STAGING_API_URL,
   LOCAL_TEST_PAGE_URL,
@@ -225,14 +221,12 @@ describe('Filter Component Core Functionality', () => {
     await page.goto(
       `${LOCAL_TEST_PAGE_URL}/applications?status=accepted&dev=true`,
     );
-    await page.waitForNetworkIdle();
 
     const acceptedStatus = 'ACCEPTED';
     const tag = await page.$(
       `${activeFilterTagsSelector} .filter__component__tag[data-status="${acceptedStatus}"]`,
     );
     expect(tag).toBeTruthy();
-
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
     const isAcceptedChecked = await page.$eval(

--- a/__tests__/components/filter.test.js
+++ b/__tests__/components/filter.test.js
@@ -60,8 +60,6 @@ describe('Filter Component Core Functionality', () => {
 
   afterEach(async () => {
     await page.close();
-  });
-  afterAll(async () => {
     await browser.close();
   });
 
@@ -88,8 +86,18 @@ describe('Filter Component Core Functionality', () => {
     expect(applyButton).toBeTruthy();
     const clearButton = await page.$(clearFilterButtonSelector);
     expect(clearButton).toBeTruthy();
-    const checkbox = await page.$(`input[type="checkbox"][id="ACCEPTED"]`);
-    expect(checkbox).toBeTruthy();
+    const acceptedCheckbox = await page.$(
+      `input[type="checkbox"][id="ACCEPTED"]`,
+    );
+    expect(acceptedCheckbox).toBeTruthy();
+    const pendingCheckbox = await page.$(
+      `input[type="checkbox"][id="PENDING"]`,
+    );
+    expect(pendingCheckbox).toBeTruthy();
+    const rejectedCheckbox = await page.$(
+      `input[type="checkbox"][id="REJECTED"]`,
+    );
+    expect(rejectedCheckbox).toBeTruthy();
   });
 
   it('should toggle the clear button state based on checkbox selection', async () => {
@@ -126,7 +134,7 @@ describe('Filter Component Core Functionality', () => {
     await page.click(`input[type="checkbox"][id="${statusToApply}"]`);
 
     await page.click(applyFilterButtonSelector);
-    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForSelector(`${filterModalSelector}.hidden`);
     await page.waitForNetworkIdle();
 
     expect(page.url()).toContain(`status=${statusToApply.toLowerCase()}`);
@@ -148,7 +156,7 @@ describe('Filter Component Core Functionality', () => {
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
     await page.click(`input[type="checkbox"][id="${statusToApply}"]`);
     await page.click(applyFilterButtonSelector);
-    await page.waitForSelector(filterModalSelector + '.hidden');
+    await page.waitForSelector(`${filterModalSelector}.hidden`);
     await page.waitForNetworkIdle();
     expect(page.url()).toContain(`status=${statusToApply.toLowerCase()}`);
 
@@ -213,33 +221,33 @@ describe('Filter Component Core Functionality', () => {
     expect(isClearButtonDisabled).toBe(true);
   });
 
-  it('should sync checkbox state and tag with URL status param on load', async () => {
+  it('should apply the appropriate filter and tag based on the page URL', async () => {
     await page.goto(
       `${LOCAL_TEST_PAGE_URL}/applications?status=accepted&dev=true`,
     );
     await page.waitForNetworkIdle();
 
-    const status = 'ACCEPTED';
+    const acceptedStatus = 'ACCEPTED';
     const tag = await page.$(
-      `${activeFilterTagsSelector} .filter__component__tag[data-status="${status}"]`,
+      `${activeFilterTagsSelector} .filter__component__tag[data-status="${acceptedStatus}"]`,
     );
     expect(tag).toBeTruthy();
 
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
     const isCheckboxChecked = await page.$eval(
-      `input[type="checkbox"][id="${status}"]`,
+      `input[type="checkbox"][id="${acceptedStatus}"]`,
       (el) => el.checked,
     );
     expect(isCheckboxChecked).toBe(true);
-    const isClearButtonDisabled = await page.$eval(
+    const isClearButtonEnable = await page.$eval(
       clearFilterButtonSelector,
-      (el) => el.disabled,
+      (el) => !el.disabled,
     );
-    expect(isClearButtonDisabled).toBe(false);
+    expect(isClearButtonEnable).toBe(true);
   });
 
-  it('should allow only single selection on application page', async () => {
+  it('should apply only one filter on application page', async () => {
     await page.click(filterButtonSelector);
     await page.waitForSelector(`${filterModalSelector}:not(.hidden)`);
 
@@ -251,16 +259,17 @@ describe('Filter Component Core Functionality', () => {
     expect(isPendingChecked).toBe(true);
 
     await page.click(`input[type="checkbox"][id="ACCEPTED"]`);
-    isPendingChecked = await page.$eval(
-      `input[type="checkbox"][id="PENDING"]`,
-      (el) => el.checked,
-    );
+
     let isAcceptedChecked = await page.$eval(
       `input[type="checkbox"][id="ACCEPTED"]`,
       (el) => el.checked,
     );
-
-    expect(isPendingChecked).toBe(false);
     expect(isAcceptedChecked).toBe(true);
+
+    isPendingChecked = await page.$eval(
+      `input[type="checkbox"][id="PENDING"]`,
+      (el) => el.checked,
+    );
+    expect(isPendingChecked).toBe(false);
   });
 });

--- a/__tests__/extension-requests/extension-requests.test.js
+++ b/__tests__/extension-requests/extension-requests.test.js
@@ -1209,4 +1209,26 @@ describe('Tests the Extension Requests Screen', () => {
       'Extension request successfully updated.',
     );
   });
+
+  it('should show only "APPROVED" and "DENIED" extension requests after selecting those filters when dev=true', async () => {
+    await page.goto(
+      `${LOCAL_TEST_PAGE_URL}/extension-requests?dev=true&order=desc`,
+    );
+    await page.waitForNetworkIdle();
+    await page.click('[data-testid="filter-component-toggle-button"]');
+    const applyFilterButton = '[data-testid="apply-filter-component-button"]';
+    await page.waitForSelector(applyFilterButton, { visible: true });
+
+    await page.click(`input[type="checkbox"][id="APPROVED"]`);
+    await page.click(`input[type="checkbox"][id="DENIED"]`);
+
+    await page.click(applyFilterButton);
+
+    await page.waitForNetworkIdle();
+
+    const extensionRequestCards = await page.$$('.extension-card');
+    expect(extensionRequestCards.length).toBe(
+      extensionRequestListForAuditLogs.allExtensionRequests.length,
+    );
+  });
 });

--- a/__tests__/extension-requests/extension-requests.test.js
+++ b/__tests__/extension-requests/extension-requests.test.js
@@ -1218,14 +1218,10 @@ describe('Tests the Extension Requests Screen', () => {
     await page.click('[data-testid="filter-component-toggle-button"]');
     const applyFilterButton = '[data-testid="apply-filter-component-button"]';
     await page.waitForSelector(applyFilterButton, { visible: true });
-
     await page.click(`input[type="checkbox"][id="APPROVED"]`);
     await page.click(`input[type="checkbox"][id="DENIED"]`);
-
     await page.click(applyFilterButton);
-
     await page.waitForNetworkIdle();
-
     const extensionRequestCards = await page.$$('.extension-card');
     expect(extensionRequestCards.length).toBe(
       extensionRequestListForAuditLogs.allExtensionRequests.length,

--- a/__tests__/requests/requests.test.js
+++ b/__tests__/requests/requests.test.js
@@ -585,4 +585,28 @@ describe('Tests the request cards', () => {
       'Request approved successfully',
     );
   });
+
+  it('should show only "APPROVED" requests after selecting "APPROVED" filter when dev=true', async () => {
+    await page.goto(`${LOCAL_TEST_PAGE_URL}/requests?dev=true`);
+    await page.waitForNetworkIdle();
+    await page.click('[data-testid="filter-component-toggle-button"]');
+    const applyFilterButton = '[data-testid="apply-filter-component-button"]';
+    await page.waitForSelector(applyFilterButton, { visible: true });
+
+    await page.click(`input[type="checkbox"][id="APPROVED"]`);
+
+    await page.click(applyFilterButton);
+
+    await page.waitForNetworkIdle();
+
+    const requestCards = await page.$$('[data-testid="ooo-request-card"]');
+
+    for (const card of requestCards) {
+      const statusText = await card.$eval(
+        '[data-testid="request-status"]',
+        (el) => el.textContent,
+      );
+      expect(statusText).toContain('Approved');
+    }
+  });
 });

--- a/__tests__/task-requests/task-request.test.js
+++ b/__tests__/task-requests/task-request.test.js
@@ -42,7 +42,9 @@ describe('Task Requests', () => {
         });
       } else if (
         url ===
-        `${STAGING_API_URL}/taskRequests?size=20&q=status%3Aapproved++sort%3Acreated-asc`
+          `${STAGING_API_URL}/taskRequests?size=20&q=status%3Aapproved++sort%3Acreated-asc` ||
+        url ===
+          `${STAGING_API_URL}/taskRequests?size=20&q=status%3Aapproved+sort%3Acreated-asc`
       ) {
         const list = [];
         for (let i = 0; i < 20; i++) {
@@ -147,6 +149,24 @@ describe('Task Requests', () => {
         const currentState = await activeFilter.getProperty('checked');
         const isChecked = await currentState.jsonValue();
         expect(isChecked).toBe(false);
+      });
+
+      it('should show approved task requests when the filter is applied and dev=true', async () => {
+        await page.goto(`${LOCAL_TEST_PAGE_URL}/task-requests?dev=true`);
+        await page.waitForNetworkIdle();
+        await page.click('[data-testid="filter-component-toggle-button"]');
+        const applyFilterButton =
+          '[data-testid="apply-filter-component-button"]';
+        await page.waitForSelector(applyFilterButton, { visible: true });
+
+        await page.click(`input[type="checkbox"][id="APPROVED"]`);
+
+        await page.click(applyFilterButton);
+
+        await page.waitForNetworkIdle();
+
+        const taskRequestList = await page.$$('.taskRequest__card');
+        expect(taskRequestList.length).toBe(20);
       });
     });
 

--- a/__tests__/task-requests/task-request.test.js
+++ b/__tests__/task-requests/task-request.test.js
@@ -151,20 +151,16 @@ describe('Task Requests', () => {
         expect(isChecked).toBe(false);
       });
 
-      it('should show approved task requests when the filter is applied and dev=true', async () => {
+      it('should show approved task requests when the approved filter is applied and dev=true', async () => {
         await page.goto(`${LOCAL_TEST_PAGE_URL}/task-requests?dev=true`);
         await page.waitForNetworkIdle();
         await page.click('[data-testid="filter-component-toggle-button"]');
         const applyFilterButton =
           '[data-testid="apply-filter-component-button"]';
         await page.waitForSelector(applyFilterButton, { visible: true });
-
         await page.click(`input[type="checkbox"][id="APPROVED"]`);
-
         await page.click(applyFilterButton);
-
         await page.waitForNetworkIdle();
-
         const taskRequestList = await page.$$('.taskRequest__card');
         expect(taskRequestList.length).toBe(20);
       });

--- a/components/filter/style.css
+++ b/components/filter/style.css
@@ -56,7 +56,7 @@
 .filter__component__modal {
   border: var(--base-light-grey-border);
   padding: 1rem;
-  margin: 3rem 0;
+  margin-top: 3rem;
   position: absolute;
   z-index: 1;
   background-color: var(--white);
@@ -93,7 +93,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  height: 2rem;
   margin-top: 1.5rem;
   justify-content: end;
   width: fit-content;

--- a/mock-data/requests/index.js
+++ b/mock-data/requests/index.js
@@ -34,6 +34,37 @@ const approvedRequest = {
   },
 };
 
+const approvedRequestsData = {
+  message: 'Request fetched successfully',
+  data: [
+    {
+      id: 'Wl4TTbpSrQDIjs6KLJwD',
+      createdAt: 1711439903761,
+      requestedBy: 'V4rqL1aDecNGoa1IxiCu',
+      from: 1712275200000,
+      until: 1712448000000,
+      type: 'OOO',
+      message: 'request message',
+      lastModifiedBy: 'V4rqL1aDecNGoa1IxiCu',
+      state: 'APPROVED',
+      updatedAt: 1711482912686,
+    },
+
+    {
+      id: 'Wl4TTbpSrQDIjs6KLJwD',
+      createdAt: 1711439903661,
+      requestedBy: 'V4rqL1aDecNGoa1IxiCu',
+      from: 1712275206600,
+      until: 1712448000000,
+      type: 'OOO',
+      message: 'request message for OOO',
+      lastModifiedBy: 'V4rqL1aDecNGoa1IxiCu',
+      state: 'APPROVED',
+      updatedAt: 1711482912686,
+    },
+  ],
+};
+
 const requestActionResponse = {
   message: 'Request approved successfully',
   data: {
@@ -108,6 +139,7 @@ const onboardingExtensionRequest = {
 module.exports = {
   pendingRequest,
   approvedRequest,
+  approvedRequestsData,
   requestActionResponse,
   extensionRequest,
   onboardingExtensionRequest,


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 29 March 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #987 
## Description

<!--Description of the changes made in this PR-->

This PR adds test coverage for the reusable Filter component.

- A dedicated test file has been created to validate the core functionality of the Filter component, including UI rendering and button event listeners.

- Since the Filter component is used across four different pages, we've also added tests in each respective page's test file to ensure that the component renders correctly and displays the appropriate content in each context.

Feature PRs

- #988 
- #989

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
- Application Page


https://github.com/user-attachments/assets/59bfa0a0-f707-4b47-9fac-67fe7d871a06



- Extension Requests Page


https://github.com/user-attachments/assets/641fa769-f72a-49b4-b3f5-39e0d5ccb591


- Requests Page

https://github.com/user-attachments/assets/b4983e32-77ef-485d-a1aa-948aa4ebc9f5



- Task-Requests Page

https://github.com/user-attachments/assets/402058f7-537a-4c5c-8b95-27174c05f494



</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/29ad7a10-98b4-4bf8-b4f4-70f0033381a2)
![image](https://github.com/user-attachments/assets/49ea42a7-ac1c-4ba3-b7de-850300fe16d2)

![image](https://github.com/user-attachments/assets/6857ac0f-77bc-4bc7-b062-589a5b91a183)
![image](https://github.com/user-attachments/assets/8d027e97-0f20-4190-88df-a00b5a64fd1b)
![image](https://github.com/user-attachments/assets/289bb3c5-caed-4823-ba2a-550016b16c47)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
