### PR TITLE
Fixes arrow on extension card

### DIFF
--- a/__tests__/extension-requests/extension-requests.test.js
+++ b/__tests__/extension-requests/extension-requests.test.js
@@ -603,6 +603,15 @@ describe('Tests the Extension Requests Screen', () => {
     expect(firstAccordionIsHidden).toBe(true);
   });
 
+  it('Renders the black down arrow icon on accordion button', async () => {
+    const firstAccordionIconSrc = await page.$eval(
+      '.extension-card:first-child .accordion img[alt="down-arrow"]',
+      (el) => el.getAttribute('src'),
+    );
+
+    expect(firstAccordionIconSrc).toBe('/images/chevron-down-black.svg');
+  });
+
   it('Checks that new items are loaded when scrolled to the bottom', async () => {
     extensionCardsList = await page.$$('.extension-card');
 

--- a/extension-requests/constants.js
+++ b/extension-requests/constants.js
@@ -1,6 +1,7 @@
 const DEFAULT_AVATAR = '/images/avatar.png';
 const EXTERNAL_LINK_ICON = '/images/external-link.svg';
 const DOWN_ARROW_ICON = '/images/chevron-down.svg';
+const DOWN_ARROW_ICON_BLACK = '/images/chevron-down-black.svg';
 const CHECK_ICON = '/images/check-icon.svg';
 const CHECK_ICON_WHITE = '/images/check-icon-white.svg';
 const CANCEL_ICON = '/images/x-icon.svg';

--- a/extension-requests/constants.js
+++ b/extension-requests/constants.js
@@ -1,7 +1,6 @@
 const DEFAULT_AVATAR = '/images/avatar.png';
 const EXTERNAL_LINK_ICON = '/images/external-link.svg';
 const DOWN_ARROW_ICON = '/images/chevron-down.svg';
-const DOWN_ARROW_ICON_BLACK = '/images/chevron-down-black.svg';
 const CHECK_ICON = '/images/check-icon.svg';
 const CHECK_ICON_WHITE = '/images/check-icon-white.svg';
 const CANCEL_ICON = '/images/x-icon.svg';

--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -1165,7 +1165,7 @@ async function createExtensionCard(data, dev) {
   accordionContainer.appendChild(accordionButton);
   const downArrowIcon = createElement({
     type: 'img',
-    attributes: { src: DOWN_ARROW_ICON_BLACK, alt: 'down-arrow' },
+    attributes: { src: ICONS.ARROW_DOWN, alt: 'down-arrow' },
   });
   accordionButton.appendChild(downArrowIcon);
   const panel = createElement({ type: 'div', attributes: { class: 'panel' } });

--- a/extension-requests/script.js
+++ b/extension-requests/script.js
@@ -1165,7 +1165,7 @@ async function createExtensionCard(data, dev) {
   accordionContainer.appendChild(accordionButton);
   const downArrowIcon = createElement({
     type: 'img',
-    attributes: { src: DOWN_ARROW_ICON, alt: 'down-arrow' },
+    attributes: { src: DOWN_ARROW_ICON_BLACK, alt: 'down-arrow' },
   });
   accordionButton.appendChild(downArrowIcon);
   const panel = createElement({ type: 'div', attributes: { class: 'panel' } });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 24/09/2025
<!--Developer Name Here-->
Developer Name: @JAHANWEE

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- closes  #1016 


## Description
This PR fixes the arrow visibility issue in the extension card when `dev=false`. Previously, the arrow was white and invisible against the white background. 

<!--Description of the changes made in this PR-->
Added a black arrow in `constants.js`.
- Replaced the white arrow with the black arrow for the `dev=false` scenario.
- Added a check to ensure the correct image is  being rendered 

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes (manual)
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots

<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->


</details>

<!--Attach or link to relevant screenshots or visual aids-->
<img width="1919" height="1048" alt="Screenshot 2025-09-25 014545" src="https://github.com/user-attachments/assets/3d1a7a22-0ec3-494a-a071-dcd1e2e325cf" />

https://github.com/user-attachments/assets/2692c1ec-4bfd-44fb-a9d6-5c8c1f4b2c07



## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="521" height="105" alt="Screenshot 2025-09-24 021207" src="https://github.com/user-attachments/assets/a5ef27b7-1faf-4712-8a6e-c6bb6abc6380" />

<img width="1913" height="57" alt="Screenshot 2025-09-24 020723" src="https://github.com/user-attachments/assets/d887f886-c39e-4994-90f1-31405094da03" />


</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations, or explanations for reviewers-->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the extension requests UI to use the black down-arrow icon on the accordion button, and add a test to verify this rendering.

### Why are these changes being made?
To ensure visual consistency with a black chevron down icon on the accordion, and to validate the UI renders the correct asset.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->