### PR TITLE
Added a label to add last used date on each group

### DIFF
--- a/__tests__/groups/group.test.js
+++ b/__tests__/groups/group.test.js
@@ -483,4 +483,56 @@ describe('Discord Groups Page', () => {
 
     expect(isAnyHidden).toBe(true);
   });
+
+  test('fullDateString should return correctly formatted string and N/A for invalid inputs', async () => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/groups/utils.js');
+      const ts = Date.UTC(2024, 10, 6, 10, 15);
+      const formatted = mod.fullDateString(ts);
+      const options = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        timeZoneName: 'short',
+        hour12: true,
+      };
+      const expected = new Intl.DateTimeFormat('en-US', options).format(
+        new Date(ts),
+      );
+      const invalidString = mod.fullDateString('abc');
+      const invalidNaN = mod.fullDateString(NaN);
+      const invalidObj = mod.fullDateString({});
+      return { formatted, expected, invalidString, invalidNaN, invalidObj };
+    });
+
+    expect(result.formatted).toBe(result.expected);
+    expect(result.invalidString).toBe('N/A');
+    expect(result.invalidNaN).toBe('N/A');
+    expect(result.invalidObj).toBe('N/A');
+  });
+
+  test('shortDateString should return correctly formatted string and N/A for invalid inputs', async () => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/groups/utils.js');
+      const ts = Date.UTC(2024, 10, 6, 10, 15);
+      const formatted = mod.shortDateString(ts);
+      const d = new Date(ts);
+      const month = new Intl.DateTimeFormat('en-US', { month: 'short' }).format(
+        d,
+      );
+      const expected = `${d.getDate()} ${month} ${d.getFullYear()}`;
+      const invalidUndef = mod.shortDateString(undefined);
+      const invalidStr = mod.shortDateString('bad');
+      const invalidNaN = mod.shortDateString(NaN);
+      return { formatted, expected, invalidUndef, invalidStr, invalidNaN };
+    });
+
+    expect(result.formatted).toBe(result.expected);
+    expect(result.invalidUndef).toBe('N/A');
+    expect(result.invalidStr).toBe('N/A');
+    expect(result.invalidNaN).toBe('N/A');
+  });
 });

--- a/__tests__/groups/group.test.js
+++ b/__tests__/groups/group.test.js
@@ -429,10 +429,12 @@ describe('Discord Groups Page', () => {
     // Find a card where last-used is visible
     const cardHandle = await page.evaluateHandle(() => {
       const cards = Array.from(document.querySelectorAll('.card'));
-      return cards.find((card) => {
-        const el = card.querySelector('.card__last-used');
-        return el && getComputedStyle(el).display !== 'none';
-      }) || null;
+      return (
+        cards.find((card) => {
+          const el = card.querySelector('.card__last-used');
+          return el && getComputedStyle(el).display !== 'none';
+        }) || null
+      );
     });
 
     expect(cardHandle).toBeTruthy();
@@ -450,11 +452,12 @@ describe('Discord Groups Page', () => {
       }
       // Fallback: take first text node only
       const first = el.childNodes[0];
-      if (first && first.nodeType === Node.TEXT_NODE) return first.textContent.trim();
+      if (first && first.nodeType === Node.TEXT_NODE)
+        return first.textContent.trim();
       return el.textContent.trim();
     }, cardHandle);
 
-    expect(lastUsedText).toMatch(/^Last used on: [A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{4}$/);
+    expect(lastUsedText).toMatch(/^Last used on: \d{1,2} [A-Za-z]{3} \d{4}$/);
 
     // Tooltip
     const tooltipText = await page.evaluate((card) => {

--- a/groups/createElements.js
+++ b/groups/createElements.js
@@ -38,21 +38,21 @@ const createCard = (
             </span>
         </div>
     `;
-  
+
   if (group.isUpdating)
     cardElement.querySelector('.card__btn').classList.add('button--blocked');
   cardElement.querySelector('.card__title').textContent = group.title;
   cardElement.querySelector('.card__description').textContent =
     group.description;
   const lastUsedElement = cardElement.querySelector('.card__last-used');
-  if (group.lastUsedOnMs) {
-    const shortFormatted = shortDateString(group.lastUsedOnMs);
+  if (group.lastUsedTimestamp) {
+    const shortFormatted = shortDateString(group.lastUsedTimestamp);
     lastUsedElement.classList.add('tooltip-container');
     lastUsedElement.textContent = `Last used on: ${shortFormatted}`;
 
     const tooltip = document.createElement('span');
     tooltip.className = 'tooltip';
-    tooltip.innerText = fullDateString(group.lastUsedOnMs);
+    tooltip.innerText = fullDateString(group.lastUsedTimestamp);
     lastUsedElement.appendChild(tooltip);
   } else {
     lastUsedElement.style.display = 'none';

--- a/groups/createElements.js
+++ b/groups/createElements.js
@@ -1,3 +1,5 @@
+import { fullDateString, shortDateString } from './utils.js';
+
 const createCard = (
   rawGroup,
   onClick = () => {},
@@ -44,27 +46,13 @@ const createCard = (
     group.description;
   const lastUsedElement = cardElement.querySelector('.card__last-used');
   if (group.lastUsedOnMs) {
-    const shortFormatted = new Intl.DateTimeFormat('en-US', {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    }).format(new Date(group.lastUsedOnMs));
+    const shortFormatted = shortDateString(group.lastUsedOnMs);
     lastUsedElement.classList.add('tooltip-container');
     lastUsedElement.textContent = `Last used on: ${shortFormatted}`;
 
     const tooltip = document.createElement('span');
     tooltip.className = 'tooltip';
-    tooltip.innerText = new Intl.DateTimeFormat('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      timeZoneName: 'short',
-      hour12: true,
-    }).format(new Date(group.lastUsedOnMs));
+    tooltip.innerText = fullDateString(group.lastUsedOnMs);
     lastUsedElement.appendChild(tooltip);
   } else {
     lastUsedElement.style.display = 'none';

--- a/groups/createElements.js
+++ b/groups/createElements.js
@@ -27,6 +27,7 @@ const createCard = (
           }  
         </div>
         <p class="card__description"></p>
+        <p class="card__last-used"></p>
         <div class="card__action">
             <button class="card__btn button"></button>
             <span class="card__count">
@@ -35,12 +36,39 @@ const createCard = (
             </span>
         </div>
     `;
-
+  
   if (group.isUpdating)
     cardElement.querySelector('.card__btn').classList.add('button--blocked');
   cardElement.querySelector('.card__title').textContent = group.title;
   cardElement.querySelector('.card__description').textContent =
     group.description;
+  const lastUsedElement = cardElement.querySelector('.card__last-used');
+  if (group.lastUsedOnMs) {
+    const shortFormatted = new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(group.lastUsedOnMs));
+    lastUsedElement.classList.add('tooltip-container');
+    lastUsedElement.textContent = `Last used on: ${shortFormatted}`;
+
+    const tooltip = document.createElement('span');
+    tooltip.className = 'tooltip';
+    tooltip.innerText = new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZoneName: 'short',
+      hour12: true,
+    }).format(new Date(group.lastUsedOnMs));
+    lastUsedElement.appendChild(tooltip);
+  } else {
+    lastUsedElement.style.display = 'none';
+  }
   cardElement.querySelector('.card__btn').textContent = group.isMember
     ? 'Remove me'
     : 'Add me';

--- a/groups/script.js
+++ b/groups/script.js
@@ -196,12 +196,12 @@ const afterAuthentication = async () => {
           .split('-')
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
           .join(' ');
-        const lastUsedOnMs =
-          group?.lastUsedOn?.seconds != null
+        const lastUsedTimestamp =
+          group?.lastUsedOn?.seconds !== undefined
             ? group.lastUsedOn.seconds * 1000
-            : group?.lastUsedOn?._seconds != null
+            : group?.lastUsedOn?._seconds !== undefined
             ? group.lastUsedOn._seconds * 1000
-            : undefined;  
+            : undefined;
         acc[group.id] = {
           id: group.id,
           title: title,
@@ -209,7 +209,7 @@ const afterAuthentication = async () => {
           isMember: group.isMember,
           roleId: group.roleid,
           description: group.description,
-          lastUsedOnMs,
+          lastUsedTimestamp,
           isUpdating: false,
         };
         return acc;

--- a/groups/script.js
+++ b/groups/script.js
@@ -196,6 +196,12 @@ const afterAuthentication = async () => {
           .split('-')
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
           .join(' ');
+        const lastUsedOnMs =
+          group?.lastUsedOn?.seconds != null
+            ? group.lastUsedOn.seconds * 1000
+            : group?.lastUsedOn?._seconds != null
+            ? group.lastUsedOn._seconds * 1000
+            : undefined;  
         acc[group.id] = {
           id: group.id,
           title: title,
@@ -203,6 +209,7 @@ const afterAuthentication = async () => {
           isMember: group.isMember,
           roleId: group.roleid,
           description: group.description,
+          lastUsedOnMs,
           isUpdating: false,
         };
         return acc;

--- a/groups/style.css
+++ b/groups/style.css
@@ -393,10 +393,8 @@ body {
 .card__last-used {
   margin-top: 0.4rem;
   color: var(--color-text-secondary);
-  font-weight: 400;
   font-size: 0.75rem;
 }
-
 
 .tooltip-container {
   position: relative;

--- a/groups/style.css
+++ b/groups/style.css
@@ -390,6 +390,39 @@ body {
   line-height: 18px;
 }
 
+.card__last-used {
+  margin-top: 0.4rem;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+  font-size: 0.75rem;
+}
+
+
+.tooltip-container {
+  position: relative;
+}
+
+.tooltip {
+  background-color: var(--black-color, #000);
+  color: var(--white, #fff);
+  visibility: hidden;
+  text-align: center;
+  border-radius: 4px;
+  padding: 0.5rem;
+  position: absolute;
+  opacity: 0.9;
+  font-size: 0.7rem;
+  width: 10rem;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5rem;
+}
+
+.tooltip-container:hover .tooltip {
+  visibility: visible;
+  transition-delay: 400ms;
+}
+
 .card__action {
   display: flex;
   justify-content: space-between;

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -178,6 +178,29 @@ function setParamValueInURL(paramKey, paramValue) {
   );
 }
 
+const fullDateString = (timestamp) => {
+  const options = {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short',
+    hour12: true,
+  };
+  return new Intl.DateTimeFormat('en-US', options).format(new Date(timestamp));
+};
+
+const shortDateString = (timestamp) => {
+  const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const date = new Date(timestamp);
+  const day = daysOfWeek[date.getDay()];
+  const year = date.getFullYear();
+  const month = new Intl.DateTimeFormat('en-US', { month: 'short' }).format(date);
+  return `${day}, ${date.getDate()} ${month} ${year}`;
+};
+
 export {
   getUserGroupRoles,
   getMembers,
@@ -191,4 +214,6 @@ export {
   getDiscordGroupIdsFromSearch,
   getParamValueFromURL,
   setParamValueInURL,
+  fullDateString,
+  shortDateString,
 };

--- a/groups/utils.js
+++ b/groups/utils.js
@@ -179,6 +179,13 @@ function setParamValueInURL(paramKey, paramValue) {
 }
 
 const fullDateString = (timestamp) => {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) {
+    return 'N/A';
+  }
+  const dateObj = new Date(timestamp);
+  if (isNaN(dateObj.getTime())) {
+    return 'N/A';
+  }
   const options = {
     weekday: 'long',
     year: 'numeric',
@@ -189,16 +196,22 @@ const fullDateString = (timestamp) => {
     timeZoneName: 'short',
     hour12: true,
   };
-  return new Intl.DateTimeFormat('en-US', options).format(new Date(timestamp));
+  return new Intl.DateTimeFormat('en-US', options).format(dateObj);
 };
 
 const shortDateString = (timestamp) => {
-  const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) {
+    return 'N/A';
+  }
   const date = new Date(timestamp);
-  const day = daysOfWeek[date.getDay()];
+  if (isNaN(date.getTime())) {
+    return 'N/A';
+  }
   const year = date.getFullYear();
-  const month = new Intl.DateTimeFormat('en-US', { month: 'short' }).format(date);
-  return `${day}, ${date.getDate()} ${month} ${year}`;
+  const month = new Intl.DateTimeFormat('en-US', { month: 'short' }).format(
+    date,
+  );
+  return `${date.getDate()} ${month} ${year}`;
 };
 
 export {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 6 Nov 2025
<!--Developer Name Here-->
Developer Name: @JAHANWEE 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #1023

## Description

<!--Description of the changes made in this PR-->
- Last used label added on the group card, displaying the last used date of each group
- Used a tooltip to maintain consistency while displaying dates 
- Business requirement: Date format intentionally does not include weekday (e.g., "12 Nov 2025" instead of "Thu, 12 Nov 2025").
### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<img width="1536" height="906" alt="Screenshot 2025-11-12 045419" src="https://github.com/user-attachments/assets/815a174b-143a-4955-92bd-dabf20afd267" />



<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="1261" height="375" alt="Screenshot 2025-11-06 202500" src="https://github.com/user-attachments/assets/f371384d-8ba3-4ea3-bcab-b425065854e0" />

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="1902" height="726" alt="image" src="https://github.com/user-attachments/assets/4e600613-db4d-4c6a-b365-a5f2d18c3d6c" />

</details>

<!--Attach Details on test coverage and outcomes-->



## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
- As discussed with Ankush, we will be dropping weekday from the date format here. 
- Note: The timestamp discrepancy observed during manual testing in the Chrome console was due to using a UNIX timestamp in seconds (e.g., 1699778432), while new Date() expects milliseconds. In the actual code, timestamps are already in milliseconds, so the function produces the correct date.
- Have noticed fullDateString and shortDateString being repeated several times in the codebase, will make a fresh PR for the cleanup of the code, and will also move the tests from group.test.js to util.test.js accordingly.
- A follow-up issue has been created to:
  - Consolidate all date utilities,
  - Add an includeWeekday option to support both format styles,
  - Move the unit tests accordingly.
- This avoids blocking the current feature while still ensuring the future cleanup is tracked.